### PR TITLE
Changed defaultconnectionstring name to MS_TableConnectionString

### DIFF
--- a/Slack.Automation/Promact.Erp.DomainModel/Context/PromactErpContext.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/Context/PromactErpContext.cs
@@ -9,7 +9,7 @@ namespace Promact.Erp.DomainModel.Context
     public class PromactErpContext : IdentityDbContext<ApplicationUser>
     {
         public PromactErpContext()
-            : base("DefaultConnection", throwIfV1Schema: false)
+            : base("MS_TableConnectionString", throwIfV1Schema: false)
         {
 
         }

--- a/Slack.Automation/Promact.Erp.Web/Web.config
+++ b/Slack.Automation/Promact.Erp.Web/Web.config
@@ -12,7 +12,7 @@
   <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   </nlog>
   <connectionStrings>
-    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-SlashCommand-20160725100110.mdf;Initial Catalog=aspnet-SlashCommand-20160725100110;Integrated Security=True" providerName="System.Data.SqlClient" />
+    <add name="MS_TableConnectionString" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-SlashCommand-20160725100110.mdf;Initial Catalog=aspnet-SlashCommand-20160725100110;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <system.net>
   </system.net>


### PR DESCRIPTION
Changed defaultconnectionstring name to MS_TableConnectionString

Changes in web.config and PromactErpContext.cs
