### PR TITLE
Slack Event handled and Manual Channel Addition Implemented

### DIFF
--- a/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/IOAuthLoginRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/IOAuthLoginRepository.cs
@@ -15,5 +15,6 @@ namespace Promact.Core.Repository.ExternalLoginRepository
         OAuthApplication ExternalLoginInformation(string refreshToken);
         Task AddSlackUserInformation(string code);
         void SlackEventUpdate(SlackEventApiAC slackEvent);
+        void SlackChannelAdd(SlackEventApiAC slackEvent);
     }
 }

--- a/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/OAuthLoginRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/OAuthLoginRepository.cs
@@ -119,9 +119,8 @@ namespace Promact.Core.Repository.ExternalLoginRepository
             var user = _slackUserDetails.FirstOrDefault(x => x.UserId == slackEvent.Event.User.UserId);
             if (user == null)
             {
-                slackEvent.Event.User.TeamId = slackEvent.TeamId;
-                _slackUserDetails.Insert(slackEvent.Event.User);
-                _slackUserDetails.Save();
+                if (!slackEvent.Event.User.IsBot)
+                    _slackUserRepository.AddSlackUser(slackEvent.Event.User);
             }
         }
 
@@ -131,7 +130,7 @@ namespace Promact.Core.Repository.ExternalLoginRepository
         /// </summary>
         /// <param name="slackEvent"></param>
         public void SlackChannelAdd(SlackEventApiAC slackEvent)
-        {           
+        {
             var channel = _slackChannelDetails.FirstOrDefault(x => x.ChannelId == slackEvent.Event.Channel.ChannelId);
             if (channel == null)
             {
@@ -139,7 +138,6 @@ namespace Promact.Core.Repository.ExternalLoginRepository
                 _slackChannelDetails.Insert(slackEvent.Event.Channel);
             }
         }
-
 
     }
 }

--- a/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/OAuthLoginRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/OAuthLoginRepository.cs
@@ -116,8 +116,30 @@ namespace Promact.Core.Repository.ExternalLoginRepository
         /// <param name="slackEvent"></param>
         public void SlackEventUpdate(SlackEventApiAC slackEvent)
         {
-            slackEvent.Event.User.TeamId = slackEvent.TeamId;
-            _slackUserDetails.Insert(slackEvent.Event.User);
+            var user = _slackUserDetails.FirstOrDefault(x => x.UserId == slackEvent.Event.User.UserId);
+            if (user == null)
+            {
+                slackEvent.Event.User.TeamId = slackEvent.TeamId;
+                _slackUserDetails.Insert(slackEvent.Event.User);
+                _slackUserDetails.Save();
+            }
         }
+
+
+        /// <summary>
+        /// Method to update slack channel table when a channel is added in team.
+        /// </summary>
+        /// <param name="slackEvent"></param>
+        public void SlackChannelAdd(SlackEventApiAC slackEvent)
+        {           
+            var channel = _slackChannelDetails.FirstOrDefault(x => x.ChannelId == slackEvent.Event.Channel.ChannelId);
+            if (channel == null)
+            {
+                slackEvent.Event.Channel.CreatedOn = DateTime.UtcNow;
+                _slackChannelDetails.Insert(slackEvent.Event.Channel);
+            }
+        }
+
+
     }
 }

--- a/Slack.Automation/Promact.Core.Test/OAuthLoginRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/OAuthLoginRepositoryTest.cs
@@ -110,6 +110,17 @@ namespace Promact.Core.Test
             Name = StringConstant.Employee
         };
 
+
+        private static SlackProfile profile = new SlackProfile()
+        {
+            Skype = StringConstant.TestUserId,
+            Email = StringConstant.EmailForTest,
+            FirstName = StringConstant.UserNameForTest,
+            LastName = StringConstant.TestUser,
+            Phone = StringConstant.PhoneForTest,
+            Title = StringConstant.TitleForTest
+        };
+
         private SlackEventApiAC slackEvent = new SlackEventApiAC()
         {
             ApiAppId = StringConstant.StringIdForTest,
@@ -126,7 +137,8 @@ namespace Promact.Core.Test
                     Deleted = false,
                     Name = StringConstant.FirstNameForTest,
                     TeamId = StringConstant.ChannelIdForTest,
-                    UserId = StringConstant.StringIdForTest
+                    UserId = StringConstant.StringIdForTest,
+                    Profile = profile
                 }
             }
         };

--- a/Slack.Automation/Promact.Core.Test/OAuthLoginRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/OAuthLoginRepositoryTest.cs
@@ -3,10 +3,12 @@ using Moq;
 using Promact.Core.Repository.AttachmentRepository;
 using Promact.Core.Repository.ExternalLoginRepository;
 using Promact.Core.Repository.HttpClientRepository;
+using Promact.Core.Repository.SlackChannelRepository;
 using Promact.Core.Repository.SlackUserRepository;
 using Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse;
 using Promact.Erp.Util;
 using Promact.Erp.Util.EnvironmentVariableRepository;
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -18,6 +20,7 @@ namespace Promact.Core.Test
         private readonly IOAuthLoginRepository _oAuthLoginRepository;
         private readonly IAttachmentRepository _attachmentRepository;
         private readonly ISlackUserRepository _slackUserRepository;
+        private readonly ISlackChannelRepository _slackChannelRepository;
         private readonly Mock<IHttpClientRepository> _mockHttpClient;
         private readonly IEnvironmentVariableRepository _envVariableRepository;
         public OAuthLoginRepositoryTest()
@@ -26,6 +29,7 @@ namespace Promact.Core.Test
             _oAuthLoginRepository = _componentContext.Resolve<IOAuthLoginRepository>();
             _attachmentRepository = _componentContext.Resolve<IAttachmentRepository>();
             _slackUserRepository = _componentContext.Resolve<ISlackUserRepository>();
+            _slackChannelRepository = _componentContext.Resolve<ISlackChannelRepository>();
             _mockHttpClient = _componentContext.Resolve<Mock<IHttpClientRepository>>();
             _envVariableRepository = _componentContext.Resolve<IEnvironmentVariableRepository>();
         }
@@ -85,6 +89,26 @@ namespace Promact.Core.Test
             var user = _slackUserRepository.GetById(slackEvent.Event.User.UserId);
             Assert.Equal(user.Name, slackEvent.Event.User.Name);
         }
+
+        /// <summary>
+        /// Test case to check SlackEventUpdate of OAuth Login Repository
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public void SlackAddChannel()
+        {
+            slackEvent.Event.Channel = channel;
+            _oAuthLoginRepository.SlackChannelAdd(slackEvent);
+            var channelAdded = _slackChannelRepository.GetById(slackEvent.Event.Channel.ChannelId);
+            Assert.Equal(channelAdded.Name, slackEvent.Event.Channel.Name);
+        }
+        
+        private SlackChannelDetails channel = new SlackChannelDetails()
+        {
+            ChannelId = "ChannelIdForTest",
+            CreatedOn = DateTime.UtcNow,
+            Deleted = false,
+            Name = StringConstant.Employee
+        };
 
         private SlackEventApiAC slackEvent = new SlackEventApiAC()
         {

--- a/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
@@ -1276,6 +1276,73 @@ namespace Promact.Core.Test
         #endregion
 
 
+        #region AddChannel Test Cases
+
+
+        /// <summary>
+        /// Method AddChannelManually Testing
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannel()
+        {
+            UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(user);
+            await _userManager.AddLoginAsync(user.Id, info);
+
+            var projectResponse = Task.FromResult(StringConstant.ProjectDetailsFromOauth);
+            var projectRequestUrl = string.Format("{0}{1}", StringConstant.ProjectDetailsUrl, StringConstant.GroupName);
+            _mockHttpClient.Setup(x => x.GetAsync(StringConstant.ProjectUrl, projectRequestUrl, StringConstant.AccessTokenForTest)).Returns(projectResponse);
+         
+            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
+            Assert.Equal(msg, StringConstant.ChannelAddSuccess);
+        }
+
+
+        /// <summary>
+        /// Method AddChannelManually Testing with Not Privaet Group
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannelNotPrivateGroup()
+        {
+            channel.Name = StringConstant.GroupName;
+            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, StringConstant.GroupName);
+            Assert.Equal(msg, StringConstant.OnlyPrivateChannel);
+        }
+
+
+        /// <summary>
+        /// Method AddChannelManually Testing with No User
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannelNoUser()
+        {
+            var projectResponse = Task.FromResult(StringConstant.ProjectDetailsFromOauth);
+            var projectRequestUrl = string.Format("{0}{1}", StringConstant.ProjectDetailsUrl, StringConstant.GroupName);
+            _mockHttpClient.Setup(x => x.GetAsync(StringConstant.ProjectUrl, projectRequestUrl, StringConstant.AccessTokenForTest)).Returns(projectResponse);
+
+            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
+            Assert.Equal(msg, StringConstant.YouAreNotInExistInOAuthServer);
+        }
+
+
+        /// <summary>
+        /// Method AddChannelManually Testing with no project added
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannelNoProject()
+        {
+            UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(user);
+            await _userManager.AddLoginAsync(user.Id, info);
+
+            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
+            Assert.Equal(msg, StringConstant.ProjectNotInOAuth);
+        }
+
+
+        #endregion
+
+
         #endregion
 
 

--- a/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
@@ -1293,46 +1293,49 @@ namespace Promact.Core.Test
         }
 
 
-        ///// <summary>
-        ///// Method AddChannelManually Testing with Not Privaet Group
-        ///// </summary>
-        //[Fact, Trait("Category", "Required")]
-        //public async void AddChannelNotPrivateGroup()
-        //{
-        //    channel.Name = StringConstant.GroupName;
-        //    var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, StringConstant.GroupName);
-        //    Assert.Equal(msg, StringConstant.OnlyPrivateChannel);
-        //}
+        /// <summary>
+        /// Method AddChannelManually Testing with Not Privaet Group
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannelNotPrivateGroup()
+        {
+            _slackUserRepository.AddSlackUser(slackUserDetails);
+            UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(user);
+            await _userManager.AddLoginAsync(user.Id, info);
+
+            var msg = await _scrumBotRepository.ProcessMessages(slackUserDetails.UserId, StringConstant.GroupName, StringConstant.Add + " " + StringConstant.Channel + " " + StringConstant.GroupName);
+            Assert.Equal(msg, StringConstant.OnlyPrivateChannel);
+        }
 
 
-        ///// <summary>
-        ///// Method AddChannelManually Testing with No User
-        ///// </summary>
-        //[Fact, Trait("Category", "Required")]
-        //public async void AddChannelNoUser()
-        //{
-        //    var projectResponse = Task.FromResult(StringConstant.ProjectDetailsFromOauth);
-        //    var projectRequestUrl = string.Format("{0}{1}", StringConstant.ProjectDetailsUrl, StringConstant.GroupName);
-        //    _mockHttpClient.Setup(x => x.GetAsync(StringConstant.ProjectUrl, projectRequestUrl, StringConstant.AccessTokenForTest)).Returns(projectResponse);
+        /// <summary>
+        /// Method AddChannelManually Testing with No User
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannelNoUser()
+        {
+            _slackUserRepository.AddSlackUser(slackUserDetails);
 
-        //    var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
-        //    Assert.Equal(msg, StringConstant.YouAreNotInExistInOAuthServer);
-        //}
+            var msg = await _scrumBotRepository.ProcessMessages(slackUserDetails.UserId, slackChannelDetails.ChannelId, StringConstant.Add + " " + StringConstant.Channel + " " + StringConstant.GroupName);
+            Assert.Equal(msg, StringConstant.YouAreNotInExistInOAuthServer);
+        }
 
 
-        ///// <summary>
-        ///// Method AddChannelManually Testing with no project added
-        ///// </summary>
-        //[Fact, Trait("Category", "Required")]
-        //public async void AddChannelNoProject()
-        //{
-        //    UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
-        //    await _userManager.CreateAsync(user);
-        //    await _userManager.AddLoginAsync(user.Id, info);
+        /// <summary>
+        /// Method AddChannelManually Testing with no project added
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async void AddChannelNoProject()
+        {
+            _slackUserRepository.AddSlackUser(slackUserDetails);
+            UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(user);
+            await _userManager.AddLoginAsync(user.Id, info);
 
-        //    var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
-        //    Assert.Equal(msg, StringConstant.ProjectNotInOAuth);
-        //}
+            var msg = await _scrumBotRepository.ProcessMessages(slackUserDetails.UserId, slackChannelDetails.ChannelId, StringConstant.Add + " " + StringConstant.Channel + " " + StringConstant.GroupName);
+            Assert.Equal(msg, StringConstant.ProjectNotInOAuth);
+        }
 
 
         #endregion

--- a/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
@@ -1269,7 +1269,7 @@ namespace Promact.Core.Test
         {
             _slackUserRepository.AddSlackUser(slackUserDetails);
             var msg = await _scrumBotRepository.ProcessMessages(StringConstant.StringIdForTest, StringConstant.GroupName, StringConstant.GroupDetailsResponseText);
-            Assert.Equal(msg, StringConstant.NotAProject);
+            Assert.Equal(msg, StringConstant.ChannelAddInstruction);
         }
 
 
@@ -1285,59 +1285,54 @@ namespace Promact.Core.Test
         [Fact, Trait("Category", "Required")]
         public async void AddChannel()
         {
-            UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
-            await _userManager.CreateAsync(user);
-            await _userManager.AddLoginAsync(user.Id, info);
+            _slackUserRepository.AddSlackUser(slackUserDetails);
+            UserProjectSetup();
 
-            var projectResponse = Task.FromResult(StringConstant.ProjectDetailsFromOauth);
-            var projectRequestUrl = string.Format("{0}{1}", StringConstant.ProjectDetailsUrl, StringConstant.GroupName);
-            _mockHttpClient.Setup(x => x.GetAsync(StringConstant.ProjectUrl, projectRequestUrl, StringConstant.AccessTokenForTest)).Returns(projectResponse);
-         
-            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
+            var msg = await _scrumBotRepository.ProcessMessages(slackUserDetails.UserId, slackChannelDetails.ChannelId, StringConstant.Add + " " + StringConstant.Channel + " " + slackChannelDetails.Name);
             Assert.Equal(msg, StringConstant.ChannelAddSuccess);
         }
 
 
-        /// <summary>
-        /// Method AddChannelManually Testing with Not Privaet Group
-        /// </summary>
-        [Fact, Trait("Category", "Required")]
-        public async void AddChannelNotPrivateGroup()
-        {
-            channel.Name = StringConstant.GroupName;
-            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, StringConstant.GroupName);
-            Assert.Equal(msg, StringConstant.OnlyPrivateChannel);
-        }
+        ///// <summary>
+        ///// Method AddChannelManually Testing with Not Privaet Group
+        ///// </summary>
+        //[Fact, Trait("Category", "Required")]
+        //public async void AddChannelNotPrivateGroup()
+        //{
+        //    channel.Name = StringConstant.GroupName;
+        //    var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, StringConstant.GroupName);
+        //    Assert.Equal(msg, StringConstant.OnlyPrivateChannel);
+        //}
 
 
-        /// <summary>
-        /// Method AddChannelManually Testing with No User
-        /// </summary>
-        [Fact, Trait("Category", "Required")]
-        public async void AddChannelNoUser()
-        {
-            var projectResponse = Task.FromResult(StringConstant.ProjectDetailsFromOauth);
-            var projectRequestUrl = string.Format("{0}{1}", StringConstant.ProjectDetailsUrl, StringConstant.GroupName);
-            _mockHttpClient.Setup(x => x.GetAsync(StringConstant.ProjectUrl, projectRequestUrl, StringConstant.AccessTokenForTest)).Returns(projectResponse);
+        ///// <summary>
+        ///// Method AddChannelManually Testing with No User
+        ///// </summary>
+        //[Fact, Trait("Category", "Required")]
+        //public async void AddChannelNoUser()
+        //{
+        //    var projectResponse = Task.FromResult(StringConstant.ProjectDetailsFromOauth);
+        //    var projectRequestUrl = string.Format("{0}{1}", StringConstant.ProjectDetailsUrl, StringConstant.GroupName);
+        //    _mockHttpClient.Setup(x => x.GetAsync(StringConstant.ProjectUrl, projectRequestUrl, StringConstant.AccessTokenForTest)).Returns(projectResponse);
 
-            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
-            Assert.Equal(msg, StringConstant.YouAreNotInExistInOAuthServer);
-        }
+        //    var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
+        //    Assert.Equal(msg, StringConstant.YouAreNotInExistInOAuthServer);
+        //}
 
 
-        /// <summary>
-        /// Method AddChannelManually Testing with no project added
-        /// </summary>
-        [Fact, Trait("Category", "Required")]
-        public async void AddChannelNoProject()
-        {
-            UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
-            await _userManager.CreateAsync(user);
-            await _userManager.AddLoginAsync(user.Id, info);
+        ///// <summary>
+        ///// Method AddChannelManually Testing with no project added
+        ///// </summary>
+        //[Fact, Trait("Category", "Required")]
+        //public async void AddChannelNoProject()
+        //{
+        //    UserLoginInfo info = new UserLoginInfo(StringConstant.PromactStringName, StringConstant.AccessTokenForTest);
+        //    await _userManager.CreateAsync(user);
+        //    await _userManager.AddLoginAsync(user.Id, info);
 
-            var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
-            Assert.Equal(msg, StringConstant.ProjectNotInOAuth);
-        }
+        //    var msg = await _scrumBotRepository.AddChannelManually(channel.Name, user.SlackUserName, channel.ChannelId);
+        //    Assert.Equal(msg, StringConstant.ProjectNotInOAuth);
+        //}
 
 
         #endregion

--- a/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
@@ -109,9 +109,14 @@ namespace Promact.Erp.Core.Controllers
                 {
                     return Ok(slackEvent.Challenge);
                 }
-                if (slackEvent.Type == StringConstant.TeamJoin)
+                if (slackEvent.Event.Type == StringConstant.TeamJoin)
                 {
                     _oAuthLoginRepository.SlackEventUpdate(slackEvent);
+                    return Ok();
+                }
+                else if(slackEvent.Event.Type == "channel_created" || slackEvent.Event.Type =="group_open")
+                {
+                   _oAuthLoginRepository.SlackChannelAdd(slackEvent);
                     return Ok();
                 }
                 else

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackEventDetailAC.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackEventDetailAC.cs
@@ -8,5 +8,7 @@ namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
         public string Type { get; set; }
         [JsonProperty("user")]
         public SlackUserDetails User { get; set; }
+        [JsonProperty("channel")]
+        public SlackChannelDetails Channel { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/AppSettingUtil.cs
+++ b/Slack.Automation/Promact.Erp.Util/AppSettingUtil.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Configuration;
 
 namespace Promact.Erp.Util
 {

--- a/Slack.Automation/Promact.Erp.Util/StringConstant.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstant.cs
@@ -56,6 +56,13 @@ namespace Promact.Erp.Util
         public static string ScrumTime = "scrum time";
         public static string ScrumHalt = "scrum halt";
         public static string ScrumHalted = "Scrum has been halted";
+        public static string ChannelAddSuccess = "Channel details has been added";
+        public static string Add = "add";
+        public static string Channel = "channel";
+        public static string ChannelAddInstruction = "The channel is not in our database. Please write the command *add channel _channelname_* , if it is added as a project in OAuth server.";
+        public static string ProjectNotInOAuth = "This group doesn't is not registered as Project in OAuth. Please add it to OAuth first";
+        public static string GroupNameStartsWith = "G";
+        public static string OnlyPrivateChannel = "Only private channels can be added manually.";
         public static string ScrumAlreadyHalted = "Scrum is already halted. Enter *scrum resume* to resume scrum";
         public static string ScrumResume = "scrum resume";
         public static string Scrum = "scrum";
@@ -280,12 +287,12 @@ namespace Promact.Erp.Util
         public static string RoleTeamLeader = "TeamLeader";
         public static string RoleEmployee = "Employee";
 
-        
+
 
         public static string ProjectUasrInformationUrl = "featchListOfUser/";
         public static string ProjectInformationUrl = "featchUserRole/";
 
-   
+
 
 
         public static string NotAvailable = "Not Available";

--- a/Slack.Automation/Promact.Erp.Util/StringConstant.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstant.cs
@@ -178,7 +178,7 @@ namespace Promact.Erp.Util
         public static string SlackBotStringName = "slackbot";
         public static string CasualLeaveUrl = "casual/leave/";
         public static string CasualLeaveResponse = "{\"casualLeave\":10.0,\"sickLeave\":5.0}";
-        public static string SlackChannelIdForTest = "DA4ADFD44";
+        public static string SlackChannelIdForTest = "GA4ADFD44";
         public static string MessageTsForTest = "5212201241.15452124";
         public static string SorryYouCannotApplyLeave = "Sorry user can't apply leave. Either user are not in Promact OAuth or yet u haven't login in promact-slack server";
         public static string LeaveListCommandForTest = "list siddhartha";


### PR DESCRIPTION
Slack Events(like team_join and channel_created) handled and Manual Channel Addition Implemented as per Issue #60

**Files Changed are:** 

**OAuthController.cs**  - Updated SlackEvent  controller for event handling
**IOAuthLoginRepository.cs** – Added SlackChannelAdd  method for channel_create and group_open event handling.
**OAuthLoginRepository.cs**  - Implemented SlackChannelAdd and updated SlackEventUpdate                          method . Changes after more slack user properties added.
**OauthLoginRepositoryTest.cs** – Updated test cases for the above given methods and updated it after  rebase.
**AppSettingUtil.cs**  - Unnecessary usings removed

**ScrumBotRepository.cs** – Added method for manual addition of channels. 
                             Changes after rebase(bot logic shifted to repository)

**ScrumBotRepositoryTest.cs**  - Updated test cases for the newly added methods and after rebase.

**SlackEventDetailAC.cs** – Added slack channel property
**AppSettingUtil.cs**  - Added a unnecessary using
**StringConstant.cs** – Added string constants.
