### PR TITLE
Redirect to page after slack authorization and integration of slack app

### DIFF
--- a/Slack.Automation/Promact.Erp.Core/Controllers/HomeController.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/HomeController.cs
@@ -61,6 +61,35 @@ namespace Promact.Erp.Core.Controllers
             return View();
         }
 
+
+        /**
+       * @api {get} Home/SlackAuthorize
+       * @apiVersion 1.0.0
+       * @apiName SlackAuthorize
+       * @apiGroup SlackAuthorize   
+       * @apiParam {string} Name  message 
+       * @apiSuccessExample {json} Success-Response:
+       * HTTP/1.1 200 OK 
+       * {
+       *     "Description":"After Slack OAuth Authorization, user is redirected here with the status of Authorization message."
+       * }
+       */
+        public ActionResult SlackAuthorize(string message)
+        {
+            try
+            {
+                ViewBag.Message = message;
+                return View();
+            }
+            catch (Exception ex)
+            {
+                var errorMessage = string.Format("{0}. Error -> {1}", StringConstant.LoggerErrorMessageHomeControllerAuthorizeStatusPage, ex.ToString());
+                _logger.Error(errorMessage, ex);
+                throw ex;
+            }
+        }
+
+
         /**
         * @api {get} Home/ExtrenalLogin
         * @apiVersion 1.0.0

--- a/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
@@ -74,27 +74,31 @@ namespace Promact.Erp.Core.Controllers
         [Route("oAuth/SlackRequest")]
         public async Task<IHttpActionResult> SlackOAuth(string code)
         {
+            string message = string.Empty;
+            var errorMessage = string.Empty;
             try
             {
                 await _oAuthLoginRepository.AddSlackUserInformation(code);
-                //  return Ok();
-                var newUrl = this.Url.Link("Default", new
-                {
-                    Controller = "Home",
-                    Action = "SlackAuthorize",
-                    message = "parameterContent"
-                });
-
-                //    return Request.CreateResponse(HttpStatusCode.OK, new { Success = true, RedirectUrl = newUrl });
-
-                return Redirect(newUrl);
+                message = StringConstant.SlackAppAdded;
+            }
+            catch (SlackAuthorizeException authEx)
+            {
+                errorMessage = string.Format("{0}. Error -> {1}", StringConstant.LoggerErrorMessageOAuthControllerSlackDetailsAdd, authEx.ToString());
+                message = StringConstant.SlackAppError + authEx.Message;
             }
             catch (Exception ex)
             {
-                var errorMessage = string.Format("{0}. Error -> {1}", StringConstant.LoggerErrorMessageOAuthControllerSlackOAuth, ex.ToString());
-                _logger.Error(errorMessage, ex);
-                throw ex;
+                errorMessage = string.Format("{0}. Error -> {1}", StringConstant.LoggerErrorMessageOAuthControllerSlackOAuth, ex.ToString());
+                message = StringConstant.SlackAppError + ex.Message;
             }
+            _logger.Error(errorMessage);
+            var newUrl = this.Url.Link("Default", new
+            {
+                Controller = "Home",
+                Action = "SlackAuthorize",
+                message = message
+            });
+            return Redirect(newUrl);
         }
 
         /**

--- a/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
@@ -77,7 +77,17 @@ namespace Promact.Erp.Core.Controllers
             try
             {
                 await _oAuthLoginRepository.AddSlackUserInformation(code);
-                return Ok();
+                //  return Ok();
+                var newUrl = this.Url.Link("Default", new
+                {
+                    Controller = "Home",
+                    Action = "SlackAuthorize",
+                    message = "parameterContent"
+                });
+
+                //    return Request.CreateResponse(HttpStatusCode.OK, new { Success = true, RedirectUrl = newUrl });
+
+                return Redirect(newUrl);
             }
             catch (Exception ex)
             {

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackChannelResponse.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackChannelResponse.cs
@@ -20,5 +20,11 @@ namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
         /// </summary>
         [JsonProperty("channels")]
         public List<SlackChannelDetails> Channels { get; set; }
+
+        /// <summary>
+        /// Error Message
+        /// </summary>
+        [JsonProperty("error")]
+        public string ErrorMessage { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackGroupDetails.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackGroupDetails.cs
@@ -5,9 +5,22 @@ namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
 {
     public class SlackGroupDetails
     {
+        /// <summary>
+        /// Bool value to get status of request to slack for getting group details
+        /// </summary>
         [JsonProperty("ok")]
         public bool Ok { get; set; }
+
+        /// <summary>
+        /// List of Slack Groups (Private Channels)
+        /// </summary>
         [JsonProperty("groups")]
         public List<SlackChannelDetails> Groups { get; set; }
+
+        /// <summary>
+        /// Error Message
+        /// </summary>
+        [JsonProperty("error")]
+        public string ErrorMessage { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackUserResponse.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackUserResponse.cs
@@ -20,5 +20,11 @@ namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
         /// </summary>
         [JsonProperty("members")]
         public List<SlackUserDetails> Members { get; set; }
+
+        /// <summary>
+        /// Error Message
+        /// </summary>
+        [JsonProperty("error")]
+        public string ErrorMessage { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/Promact.Erp.Util.csproj
+++ b/Slack.Automation/Promact.Erp.Util/Promact.Erp.Util.csproj
@@ -67,6 +67,7 @@
     <Compile Include="EnvironmentVariableRepository\EnvironmentVariableRepository.cs" />
     <Compile Include="EnvironmentVariableRepository\IEnvironmentVariableRepository.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SlackAuthorizeException.cs" />
     <Compile Include="StringConstant.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Slack.Automation/Promact.Erp.Util/SlackAuthorizeException.cs
+++ b/Slack.Automation/Promact.Erp.Util/SlackAuthorizeException.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Promact.Erp.Util
+{
+    public class SlackAuthorizeException : Exception
+    {
+        public SlackAuthorizeException()
+        {
+        }
+
+        public SlackAuthorizeException(string message)
+        : base(message)
+        {
+        }
+
+        public SlackAuthorizeException(string message, Exception inner)
+        : base(message, inner)
+        {
+        }
+    }
+}

--- a/Slack.Automation/Promact.Erp.Util/SlackAuthorizeException.cs
+++ b/Slack.Automation/Promact.Erp.Util/SlackAuthorizeException.cs
@@ -4,17 +4,30 @@ namespace Promact.Erp.Util
 {
     public class SlackAuthorizeException : Exception
     {
+        /// <summary>
+        ///  Initializes a new instance of the SlackAuthorizeException class.
+        /// </summary>
         public SlackAuthorizeException()
         {
         }
 
+        /// <summary>
+        ///    Initializes a new instance of the SlackAuthorizeException class with a specified error message.
+        /// </summary>
+        /// <param name="message">error message</param>
         public SlackAuthorizeException(string message)
         : base(message)
         {
         }
 
-        public SlackAuthorizeException(string message, Exception inner)
-        : base(message, inner)
+
+        /// <summary>
+        /// Initializes a new instance of the SlackAuthorizeException class with a specified error message and a reference to the inner exception that is the cause of this exception.        
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        public SlackAuthorizeException(string message, Exception innerException)
+        : base(message, innerException)
         {
         }
     }

--- a/Slack.Automation/Promact.Erp.Util/StringConstant.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstant.cs
@@ -47,6 +47,9 @@ namespace Promact.Erp.Util
         public static string SlackUserListUrl = "https://slack.com/api/users.list";
         public static string SlackChannelListUrl = "https://slack.com/api/channels.list";
         public static string SlackGroupListUrl = "https://slack.com/api/groups.list";
+        public static string SlackAuthError = "There is something wrong Internally.The response from Slack is : ";
+        public static string SlackAppError = "Promact Slack app was not added successfully. ";
+        public static string SlackAppAdded = "Promact Slack app has been added successfully";
         public static string TaskMailBotStatusErrorMessage = "Status should be completed/inprogress/roadblock";
         public static string TaskMailBotHourErrorMessage = "Please enter numeric value. And it should be in range of 0.5 to 8";
         public static string TaskMailDescription = "Descriptions";
@@ -169,10 +172,12 @@ namespace Promact.Erp.Util
         public static string LoggerErrorMessageLeaveRequestControllerSlackRequest = "Error in Leave Request Controller-Slack Request";
         public static string LoggerErrorMessageLeaveRequestControllerSlackButtonRequest = "Error in Leave Request Controller-Slack Button Request";
         public static string LoggerErrorMessageHomeControllerExtrenalLogin = "Error in Home Controller-Extrenal Login ";
+        public static string LoggerErrorMessageHomeControllerAuthorizeStatusPage = "Error in Home Controller-Status Page after Authorize ";
         public static string LoggerErrorMessageHomeControllerExtrenalLoginCallBack = "Error in Home Controller-Extrenal Login CallBack ";
         public static string LoggerErrorMessageHomeControllerLogoff = "Error in Home Controller-LogOff";
         public static string LoggerErrorMessageOAuthControllerRefreshToken = "Error in OAuth Controller-Refresh Token";
         public static string LoggerErrorMessageOAuthControllerSlackOAuth = "Error in OAuth Controller-Slack OAuth";
+        public static string LoggerErrorMessageOAuthControllerSlackDetailsAdd = "Error in OAuth Controller-Slack Details Add";
         public static string LoggerErrorMessageOAuthControllerSlackEvent = "Error in OAuth Controller-Slack Event";
         public static string LoggerErrorMessageTaskMailBot = "Error in Task Mail Bot";
         public static string SlackBotStringName = "slackbot";

--- a/Slack.Automation/Promact.Erp.Util/StringConstant.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstant.cs
@@ -47,6 +47,9 @@ namespace Promact.Erp.Util
         public static string SlackUserListUrl = "https://slack.com/api/users.list";
         public static string SlackChannelListUrl = "https://slack.com/api/channels.list";
         public static string SlackGroupListUrl = "https://slack.com/api/groups.list";
+        public static string SlackAuthError = "There is something wrong Internally.The response from Slack is : ";
+        public static string SlackAppError = "Promact Slack app was not added successfully. ";
+        public static string SlackAppAdded = "Promact Slack app has been added successfully";
         public static string TaskMailBotStatusErrorMessage = "Status should be completed/inprogress/roadblock";
         public static string TaskMailBotHourErrorMessage = "Please enter numeric value. And it should be in range of 0.5 to 8";
         public static string TaskMailDescription = "Descriptions";
@@ -162,10 +165,12 @@ namespace Promact.Erp.Util
         public static string LoggerErrorMessageLeaveRequestControllerSlackRequest = "Error in Leave Request Controller-Slack Request";
         public static string LoggerErrorMessageLeaveRequestControllerSlackButtonRequest = "Error in Leave Request Controller-Slack Button Request";
         public static string LoggerErrorMessageHomeControllerExtrenalLogin = "Error in Home Controller-Extrenal Login ";
+        public static string LoggerErrorMessageHomeControllerAuthorizeStatusPage = "Error in Home Controller-Status Page after Authorize ";
         public static string LoggerErrorMessageHomeControllerExtrenalLoginCallBack = "Error in Home Controller-Extrenal Login CallBack ";
         public static string LoggerErrorMessageHomeControllerLogoff = "Error in Home Controller-LogOff";
         public static string LoggerErrorMessageOAuthControllerRefreshToken = "Error in OAuth Controller-Refresh Token";
         public static string LoggerErrorMessageOAuthControllerSlackOAuth = "Error in OAuth Controller-Slack OAuth";
+        public static string LoggerErrorMessageOAuthControllerSlackDetailsAdd = "Error in OAuth Controller-Slack Details Add";
         public static string LoggerErrorMessageOAuthControllerSlackEvent = "Error in OAuth Controller-Slack Event";
         public static string LoggerErrorMessageTaskMailBot = "Error in Task Mail Bot";
         public static string SlackBotStringName = "slackbot";

--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -296,6 +296,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="Project_Readme.html" />
+    <Content Include="Views\Home\SlackAuthorize.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Promact.Core.Repository\Promact.Core.Repository.csproj">

--- a/Slack.Automation/Promact.Erp.Web/Views/Home/SlackAuthorize.cshtml
+++ b/Slack.Automation/Promact.Erp.Web/Views/Home/SlackAuthorize.cshtml
@@ -1,0 +1,12 @@
+﻿
+@{
+    ViewBag.Title = "SlackAuthorize";
+}
+
+<h4>@ViewBag.Message</h4>
+<p>
+    <a href='@Url.Action("Index", "Home")'>
+        <input type='submit' value='Back to Home' />
+    </a>
+</p>
+


### PR DESCRIPTION
User is redirected to a page which indicates the outcome of the adding slack app and slack authorization. Resolved as per Issue #64 

**Files Changed are** :
1.  **OAuthLoginRepository.cs** - AddSlackUserInformation() method modified to throw SlackAuthorizeException if the slack details were not obtained
2.  **HomeController.cs** - Added SlackAuthorize().
3.  **OAuthController.cs**\- Modified SlackOAuth() to handle exceptions and Redirect to SlackAuthorize page with appropriate message.
4.  **SlackChannelResponse.cs** - ErrorMessage property added.
5.  **SlackGroupDetails.cs** -  ErrorMessage property added.
6.  **SlackUserResponse.cs** - ErrorMessage property added.
7.  **SlackAuthorizeException.cs** - Custom Exception class created.
8.  **StringConstant.cs** - String Constants added.
9.  **SlackAuthorize.cshtml** - Page added.
