### PR TITLE
Restructure task mail module

### DIFF
--- a/Slack.Automation/Promact.Core.Repository/EmailServiceTemplateRepository/EmailServiceTemplateRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/EmailServiceTemplateRepository/EmailServiceTemplateRepository.cs
@@ -78,7 +78,7 @@ namespace Promact.Core.Repository.EmailServiceTemplateRepository
         /// </summary>
         /// <param name="taskMail">List of TaskMail</param>
         /// <returns>template emailBody as string</returns>
-        public string EmailServiceTemplateTaskMail(List<TaskMailDetails> taskMail)
+        public string EmailServiceTemplateTaskMail(IEnumerable<TaskMailDetails> taskMail)
         {
             Erp.Util.Email_Templates.TaskMail leaveTemplate = new Erp.Util.Email_Templates.TaskMail();
             // Assigning Value in template page

--- a/Slack.Automation/Promact.Core.Repository/EmailServiceTemplateRepository/IEmailServiceTemplateRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/EmailServiceTemplateRepository/IEmailServiceTemplateRepository.cs
@@ -28,7 +28,7 @@ namespace Promact.Core.Repository.EmailServiceTemplateRepository
         /// </summary>
         /// <param name="taskMail">List of TaskMail</param>
         /// <returns>template emailBody as string</returns>
-        string EmailServiceTemplateTaskMail(List<TaskMailDetails> taskMail);
+        string EmailServiceTemplateTaskMail(IEnumerable<TaskMailDetails> taskMail);
 
         /// <summary>
         /// Method to generate template body 

--- a/Slack.Automation/Promact.Core.Repository/TaskMailRepository/TaskMailRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/TaskMailRepository/TaskMailRepository.cs
@@ -28,8 +28,8 @@ namespace Promact.Core.Repository.TaskMailRepository
         private readonly IEmailService _emailService;
         private readonly ApplicationUserManager _userManager;
         private readonly IStringConstantRepository _stringConstant;
-        string questionText = "";
         private readonly IEmailServiceTemplateRepository _emailServiceTemplate;
+        string questionText;
         #endregion
 
         #region Constructor
@@ -45,6 +45,7 @@ namespace Promact.Core.Repository.TaskMailRepository
             _botQuestionRepository = botQuestionRepository;
             _userManager = userManager;
             _emailServiceTemplate = emailServiceTemplate;
+            questionText = _stringConstant.EmptyString;
         }
         #endregion
 
@@ -193,13 +194,6 @@ namespace Promact.Core.Repository.TaskMailRepository
                                             {
                                                 totalHourSpented += task.Hours;
                                             }
-                                            //var todayTaskMail = _taskMail.Fetch(x => x.EmployeeId == taskMail.EmployeeId
-                                            //&& x.CreatedOn.Date == DateTime.UtcNow.Date);
-                                            //foreach (var item in todayTaskMail)
-                                            //{
-                                            //    var recentTask = await _taskMailDetail.FirstOrDefaultAsync(x => x.TaskId == item.Id);
-                                            //    totalHourSpented += recentTask.Hours;
-                                            //}
                                             totalHourSpented += hour;
                                             if (totalHourSpented <= 8)
                                             {

--- a/Slack.Automation/Promact.Erp.Core/Controllers/Bot.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/Bot.cs
@@ -39,13 +39,12 @@ namespace Promact.Erp.Core.Controllers
         /// <summary>
         /// Used to connect task mail bot and to capture task mail
         /// </summary>
-        public void Main()
+        public void TaskMailBot()
         {
             try
             {
                 // assigning bot token on Slack Socket Client
-                string botToken = _environmentVariableRepository.TaskmailAccessToken;
-                SlackSocketClient client = new SlackSocketClient(botToken);
+                SlackSocketClient client = new SlackSocketClient(_environmentVariableRepository.TaskmailAccessToken);
                 // Creating a Action<MessageReceived> for Slack Socket Client to get connect. No use in task mail bot
                 MessageReceived messageReceive = new MessageReceived();
                 messageReceive.ok = true;
@@ -58,13 +57,13 @@ namespace Promact.Erp.Core.Controllers
                     client.OnMessageReceived += (message) =>
                     {
                         var user = _slackUserDetails.GetByIdAsync(message.user).Result;
-                        string replyText = "";
+                        string replyText = _stringConstant.EmptyString;
                         var text = message.text;
                         if (user != null)
                         {
                             if (text.ToLower() == _stringConstant.TaskMailSubject.ToLower())
                             {
-                                replyText = _taskMailRepository.StartTaskMailAsync(user.UserId).Result;
+                                replyText =  _taskMailRepository.StartTaskMailAsync(user.UserId).Result;
                             }
                             else
                             {
@@ -86,7 +85,8 @@ namespace Promact.Erp.Core.Controllers
             }
             catch (Exception ex)
             {
-                _logger.Error(_stringConstant.LoggerErrorMessageTaskMailBot + " " + ex.Message + "\n" + ex.StackTrace);
+                _logger.Error(_stringConstant.LoggerErrorMessageTaskMailBot + _stringConstant.Space + ex.Message + 
+                    Environment.NewLine + ex.StackTrace);
                 throw ex;
             }
 

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
@@ -387,5 +387,6 @@ namespace Promact.Erp.Util.StringConstants
         string Payload { get; }
         string LeaveUpdateEmailStringFormat { get; }
         string RequestToAddSlackApp { get; }
+        string Space { get; }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
@@ -2668,5 +2668,13 @@ namespace Promact.Erp.Util.StringConstants
                 return string.Format("Please add our slack app to your slack slackbot channel. Click here {0}", AppSettingUtil.PromactErpUrl);
             }
         }
+
+        public string Space
+        {
+            get
+            {
+                return " ";
+            }
+        }
     }
 }

--- a/Slack.Automation/Promact.Erp.Web/Global.asax.cs
+++ b/Slack.Automation/Promact.Erp.Web/Global.asax.cs
@@ -21,7 +21,7 @@ namespace Promact.Erp.Web
             BundleConfig.RegisterBundles(BundleTable.Bundles);
             Bot bot = container.Resolve<Bot>();
             bot.ScrumMain();
-            bot.Main();
+            bot.TaskMailBot();
         }
     }
 }


### PR DESCRIPTION
Fixes - #131 

**1. IEmailServiceTemplateRepository.cs** - Change in EmailServiceTemplateTaskMail, parameter type from List to IEnumerable
**2. EmailServiceTemplateRepository.cs** - Change in EmailServiceTemplateTaskMail, parameter type from List to IEnumerable
**3. TaskMailRepository.cs** - Fixes Promact/slack-erp-custom-integration-mvc#131 -> Restructure Task mail Module from 1NF to 2NF (Review this file in Promact/slack-erp-custom-integration-mvc#122 PR)
**4. Bot.cs** - Update stream line
**5. IStringConstantRepository.cs** - added a variable space
**6. StringConstantRepository.cs** - added a variable space
**7. Global.asax.cs** - change in naming convention for Task mail Bot