### PR TITLE
Fixes - Issue of Issuer name does not match authority

### DIFF
--- a/Slack.Automation/Promact.Erp.Web/App_Start/Startup.Auth.cs
+++ b/Slack.Automation/Promact.Erp.Web/App_Start/Startup.Auth.cs
@@ -70,7 +70,9 @@ namespace Promact.Erp.Web
                         var accessToken = tokenReceived.ProtocolMessage.AccessToken;
                         _logger.Info("AccessToken:" + accessToken);
                         _logger.Info("AppSettingUtil OAuth Url:" + AppSettingUtil.OAuthUrl);
-                        var doc = await DiscoveryClient.GetAsync(AppSettingUtil.OAuthUrl);
+                        var discovery = new DiscoveryClient(AppSettingUtil.OAuthUrl);
+                        discovery.Policy.RequireHttps = false;
+                        var doc = await discovery.GetAsync();
                         _logger.Info("Doc File:" + doc);
                         _logger.Info("Doc Info:" + doc.Error);
                         _logger.Info("Doc:" + doc.UserInfoEndpoint);


### PR DESCRIPTION
Fixes - Issue of Issuer name does not match authority: http://oauth.promactinfo.com

**1. Startup.Auth.cs** - added Https required as false