### PR TITLE
Updated README.md and External API call urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/aoenqgv5cs3idhb7/branch/dev?svg=true)](https://ci.appveyor.com/project/iroshni/slack-erp-custom-integration-mvc/branch/dev) [![Coverage Status](https://coveralls.io/repos/github/Promact/slack-erp-custom-integration-mvc/badge.svg?branch=dev)](https://coveralls.io/github/Promact/slack-erp-custom-integration-mvc?branch=dev) [![Code Climate](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc/badges/gpa.svg)](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc) [![Issue Count](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc/badges/issue_count.svg)](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc)
+Build Status
+------------
 
-[![Client Side Coverage Status](https://img.shields.io/codecov/c/github/Promact/slack-erp-custom-integration-mvc/codecovIntegration.svg)](https://codecov.io/github/Promact/slack-erp-custom-integration-mvc/commits)
+|Appveyor |Server side coverage |Client side coverage |Code Climate |Code Climate Issue Count |
+|:------:|:------:|:------:|:------:|:------:|
+|[![Build status](https://ci.appveyor.com/api/projects/status/aoenqgv5cs3idhb7/branch/dev?svg=true)](https://ci.appveyor.com/project/iroshni/slack-erp-custom-integration-mvc/branch/dev)|[![Coverage Status](https://coveralls.io/repos/github/Promact/slack-erp-custom-integration-mvc/badge.svg?branch=dev)](https://coveralls.io/github/Promact/slack-erp-custom-integration-mvc?branch=dev)|[![Client Side Coverage Status](https://img.shields.io/codecov/c/github/Promact/slack-erp-custom-integration-mvc/codecovIntegration.svg)](https://codecov.io/github/Promact/slack-erp-custom-integration-mvc/commits)|[![Code Climate](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc/badges/gpa.svg)](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc)|[![Issue Count](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc/badges/issue_count.svg)](https://codeclimate.com/github/Promact/slack-erp-custom-integration-mvc)|
 
 # slack-erp-custom-integration-mvc
 Slack Custom Integration/Apps for Leave Management, Standup Meetings, Task status.

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
@@ -169,7 +169,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
         public async Task<List<ProjectAc>> GetListOfProjectsEnrollmentOfUserByUserIdAsync(string userId, string accessToken)
         {
             List<ProjectAc> projects = new List<ProjectAc>();
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, userId);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, userId);
             var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
             if(response != null)
             {
@@ -187,8 +187,8 @@ namespace Promact.Core.Repository.OauthCallsRepository
         public async Task<List<User>> GetAllTeamMemberByProjectIdAsync(int projectId, string accessToken)
         {
             List<User> teamMembers = new List<User>();
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, projectId);
-            var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, projectId);
+            var response = await _httpClientService.GetAsync(_stringConstant.UserUrl, requestUrl, accessToken);
             if(response != null)
             {
                 teamMembers = JsonConvert.DeserializeObject<List<User>>(response);

--- a/Slack.Automation/Promact.Core.Test/OauthCallsRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/OauthCallsRepositoryTest.cs
@@ -340,7 +340,7 @@ namespace Promact.Core.Test
         public async Task GetListOfProjectsEnrollmentOfUserByUserIdAsync()
         {
             var responseProjects = Task.FromResult(_stringConstant.ProjectDetailsForAdminFromOauth);
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, _stringConstant.StringIdForTest);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, requestUrl, _stringConstant.AccessTokenForTest)).Returns(responseProjects);
             var result = await _oauthCallsRepository.GetListOfProjectsEnrollmentOfUserByUserIdAsync(_stringConstant.StringIdForTest, _stringConstant.AccessTokenForTest);
             Assert.NotEqual(result.Count, 0);
@@ -354,11 +354,11 @@ namespace Promact.Core.Test
         public async Task GetAllTeamMemberByProjectIdAsync()
         {
             var responseProjects = Task.FromResult(_stringConstant.ManagementDetailsFromOauthServer);
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, 1);
-            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, requestUrl, _stringConstant.AccessTokenForTest)).Returns(responseProjects);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, 1);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.UserUrl, requestUrl, _stringConstant.AccessTokenForTest)).Returns(responseProjects);
             var result = await _oauthCallsRepository.GetAllTeamMemberByProjectIdAsync(1, _stringConstant.AccessTokenForTest);
             Assert.NotEqual(result.Count, 0);
-            _mockHttpClient.Verify(x => x.GetAsync(_stringConstant.ProjectUrl, requestUrl, _stringConstant.AccessTokenForTest), Times.Once);
+            _mockHttpClient.Verify(x => x.GetAsync(_stringConstant.UserUrl, requestUrl, _stringConstant.AccessTokenForTest), Times.Once);
         }
         #endregion
 

--- a/Slack.Automation/Promact.Core.Test/SlackRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/SlackRepositoryTest.cs
@@ -104,7 +104,7 @@ namespace Promact.Core.Test
             List<ProjectAc> listOfProject = new List<ProjectAc>();
             listOfProject.Add(new ProjectAc() { Id = 1 });
             var responseProjects = Task.FromResult(JsonConvert.SerializeObject(listOfProject));
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, _stringConstant.StringIdForTest);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, requestUrl, _stringConstant.AccessTokenForTest)).Returns(responseProjects);
             slackLeave.ResponseUrl = _stringConstant.IncomingWebHookUrl;
             await AddThreeUserIncomingWebHookAsync();
@@ -482,7 +482,7 @@ namespace Promact.Core.Test
             List<ProjectAc> listOfProject = new List<ProjectAc>();
             listOfProject.Add(new ProjectAc() { Id = 1 });
             var responseProjects = Task.FromResult(JsonConvert.SerializeObject(listOfProject));
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, _stringConstant.StringIdForTest);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, requestUrl, _stringConstant.AccessTokenForTest)).Returns(responseProjects);
             slackLeave.ResponseUrl = _stringConstant.IncomingWebHookUrl;
             await AddThreeUserIncomingWebHookAsync();
@@ -810,7 +810,7 @@ namespace Promact.Core.Test
             List<ProjectAc> listOfProject = new List<ProjectAc>();
             listOfProject.Add(new ProjectAc() { Id = 1 });
             var responseProjects = Task.FromResult(JsonConvert.SerializeObject(listOfProject));
-            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, _stringConstant.StringIdForTest);
+            var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, requestUrl, _stringConstant.AccessTokenForTest)).Returns(responseProjects);
             await AddThreeUserIncomingWebHookAsync();
             SmtpException ex = new SmtpException();

--- a/Slack.Automation/Promact.Erp.Util/Email/EmailService.cs
+++ b/Slack.Automation/Promact.Erp.Util/Email/EmailService.cs
@@ -1,9 +1,9 @@
-﻿using Autofac.Extras.NLog;
-using Promact.Erp.DomainModel.ApplicationClass;
+﻿using Promact.Erp.DomainModel.ApplicationClass;
 using Promact.Erp.Util.EnvironmentVariableRepository;
 using System;
 using System.Net.Mail;
 using System.Text;
+using NLog;
 
 namespace Promact.Erp.Util.Email
 {
@@ -16,10 +16,10 @@ namespace Promact.Erp.Util.Email
 
         #region Constructor
 
-        public EmailService(IEnvironmentVariableRepository envVariableRepository, ILogger logger)
+        public EmailService(IEnvironmentVariableRepository envVariableRepository)
         {
             _envVariableRepository = envVariableRepository;
-            _logger = logger;
+            _logger = LogManager.GetLogger("EmailService");
         }
 
         #endregion
@@ -33,10 +33,10 @@ namespace Promact.Erp.Util.Email
         {
             try
             {
+                _logger.Info("something");
                 MailMessage message = new MailMessage();
                 _logger.Debug("Email send from : " + email.From);
                 message.From = new MailAddress(email.From);
-                _logger.Debug("Email send to : " + email.To);
                 foreach (var to in email.To)
                 {
                     _logger.Debug("Email send to : " + to);
@@ -58,7 +58,7 @@ namespace Promact.Erp.Util.Email
                 client.Host = _envVariableRepository.Host;
                 _logger.Debug("Email send Port : " + _envVariableRepository.Port);
                 client.Port = _envVariableRepository.Port;
-                _logger.Debug("Email send environment variable email : " + _envVariableRepository.Username);
+                _logger.Debug("Email send environment variable Username : " + _envVariableRepository.Username);
                 _logger.Debug("Email send environment variable password is null : " + string.IsNullOrEmpty(_envVariableRepository.Password));
                 client.Credentials = new System.Net.NetworkCredential(_envVariableRepository.Username, _envVariableRepository.Password);
                 _logger.Debug("Email send enableSSL : " + _envVariableRepository.EnableSsl);
@@ -70,9 +70,13 @@ namespace Promact.Erp.Util.Email
             catch (Exception ex)
             {
                 if (ex.InnerException != null)
+#pragma warning disable CS0618 // Type or member is obsolete
                     _logger.Error("Error Occured in email sending : " + ex.InnerException.Message, ex);
+#pragma warning restore CS0618 // Type or member is obsolete
                 else
+#pragma warning disable CS0618 // Type or member is obsolete
                     _logger.Error("Error Occured in email sending : " + ex.Message, ex);
+#pragma warning restore CS0618 // Type or member is obsolete
                 throw ex;
             }
         }

--- a/Slack.Automation/Promact.Erp.Util/Promact.Erp.Util.csproj
+++ b/Slack.Automation/Promact.Erp.Util/Promact.Erp.Util.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.2-beta2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.5.0.0-beta06\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -61,10 +61,12 @@
       <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.3.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.0\lib\net46\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
@@ -81,6 +83,8 @@
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
@@ -167,7 +171,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
@@ -435,5 +435,6 @@
         string ManagementGroup { get; }
         string TeamMembersGroup { get; }
         string EmailListForGroup { get; }
+        string DetailsAndSlashForUrl { get; }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
@@ -429,5 +429,6 @@
         string ScrumModule { get; }
         string LeaveModule { get; }
         string Management { get; }
+        string DetailsAndSlashForUrl { get; }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
@@ -2943,5 +2943,6 @@ namespace Promact.Erp.Util.StringConstants
         public string ManagementGroup { get { return "Management"; } }
         public string TeamMembersGroup { get { return "Team Members"; } }
         public string EmailListForGroup { get { return "{\"teamLeader\":[],\"tamMemeber\":[],\"management\":[\"julie@promactinfo.com\",\"roshni@promactinfo.com\"]}"; } }
+        public string DetailsAndSlashForUrl { get { return "detail/"; } }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
@@ -2937,5 +2937,6 @@ namespace Promact.Erp.Util.StringConstants
         public string LeaveModule { get { return "leave"; } }
         public string ScrumModule { get { return "scrum"; } }
         public string Management { get { return "Management"; } }
+        public string DetailsAndSlashForUrl { get { return "detail/"; } }
     }
 }

--- a/Slack.Automation/Promact.Erp.Util/app.config
+++ b/Slack.Automation/Promact.Erp.Util/app.config
@@ -36,7 +36,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NLog" publicKeyToken="5120e14c03d0593c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Slack.Automation/Promact.Erp.Util/packages.config
+++ b/Slack.Automation/Promact.Erp.Util/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="9.0.2-beta2" targetFramework="net461" />
-  <package id="NLog" version="2.0.0.2000" targetFramework="net461" />
+  <package id="NLog" version="5.0.0-beta06" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Http" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />

--- a/Slack.Automation/Promact.Erp.Web/NLog.config
+++ b/Slack.Automation/Promact.Erp.Web/NLog.config
@@ -36,7 +36,11 @@
     layout="Time : ${time} ${newline}Message:${message} ${exception:format=tostring}${newline}----------------------------------------------------------------------------------------------------------------------------------------------------------------${newline}"
    fileName="NLog/nlog-${shortdate}.${level}.log"/>
 
-
+    <target
+     name="emailService"
+     xsi:type="File"
+     layout="Time : ${time} ${newline}Message : ${message} ${exception:format=tostring}${newline}----------------------------------------------------------------------------------------------------------------------------------------------------------------${newline}"
+    fileName="NLog/nlog-emailService-${shortdate}.${level}.log"/>
     <!--<target xsi:type="ColoredConsole" 
             name="ColoredConsole" 
             layout="Time : ${time} ${newline}Message:${message} ${exception:format=tostring}${newline}">
@@ -51,6 +55,7 @@
     <logger name="AuthenticationModule" minlevel="Trace" writeTo="authenticationModule" />
     <logger name="ScrumBotModule" minlevel="Trace" writeTo="scrumBotModule" />
     <logger name="TaskBotModule" minlevel="Trace" writeTo="taskBotModule" />
+    <logger name="EmailService" minlevel="Trace" writeTo="emailService" />
     <!--<logger name="ColoredConsole" minlevel="Trace" writeTo="ColoredConsole" />-->
     <logger name="*" level="Trace" writeTo="ownFile-web" />
     <logger name="*" level="Error" writeTo="ownFile-web" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ cache:
 - "%LOCALAPPDATA%\\Yarn"
 - "%APPVEYOR_BUILD_FOLDER%\\Slack.Automation\\packages"
 build_script:
-- cmd: "nuget restore \".\\Slack.Automation\\Promact.ERP.sln\"\nnpm i -g yarn && yarn global add typescript typings\ncd \".\\Slack.Automation\\Promact.Erp.Web\"\nyarn\ncd \"..\\..\"\nmsbuild \".\\Slack.Automation\\Promact.ERP.sln\" /m /verbosity:minimal /logger:\"C:\\Program Files\\AppVeyor\\BuildAgent\\Appveyor.MSBuildLogger.dll\" /p:Optimize=False"
+- cmd: "nuget restore \".\\Slack.Automation\\Promact.ERP.sln\"\nnpm i -g yarn@0.16.1 && yarn global add typescript typings\ncd \".\\Slack.Automation\\Promact.Erp.Web\"\nyarn\ncd \"..\\..\"\nmsbuild \".\\Slack.Automation\\Promact.ERP.sln\" /m /verbosity:minimal /logger:\"C:\\Program Files\\AppVeyor\\BuildAgent\\Appveyor.MSBuildLogger.dll\" /p:Optimize=False"
 build:
  project: .\Slack.Automation\Promact.ERP.sln
  parallel: true


### PR DESCRIPTION
Fixes - #233 

**1. README.md** - added table structure for view report of build and coverage
**2. appveyor.yml** - fixed the version of yarn to 0.16.1
**3. OauthCallsRepositoryTest.cs** - updated the test cases
**4. SlackRepositoryTest.cs** - updated the test cases
**5. IStringConstantRepository.cs** - added DetailsAndSlashForUrl
**6. StringConstantRepository.cs** - added DetailsAndSlashForUrl
**7. EmailService.cs** - added logger of email service module
**8. app.config** - updated the version of nlog
**9. packages.config** - updated the version of nlog
**10. NLog.config** - added email service logger