### PR TITLE
Fixes - leave command error message not display proper

### DIFF
--- a/Slack.Automation/Promact.Core.Repository/SlackRepository/SlackRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/SlackRepository/SlackRepository.cs
@@ -346,7 +346,7 @@ namespace Promact.Core.Repository.SlackRepository
                 }
                 else
                     // if date is not proper than date format error message will be send to user
-                    replyText = _stringConstant.DateFormatErrorMessage;
+                    replyText = string.Format(_stringConstant.DateFormatErrorMessage, dateFormat);
             }
             catch (SmtpException ex)
             {

--- a/Slack.Automation/Promact.Core.Test/SlackRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/SlackRepositoryTest.cs
@@ -580,11 +580,12 @@ namespace Promact.Core.Test
         [Fact, Trait("Category", "Required")]
         public async Task LeaveApplyForErrorDateFormatAsync()
         {
+            var dateFormat = Thread.CurrentThread.CurrentCulture.DateTimeFormat.ShortDatePattern;
             await AddUser();
             await AddThreeUserIncomingWebHookAsync();
             slackLeave.Text = _stringConstant.SlashCommandTextErrorDateFormatSick;
             MockingOfUserDetails();
-            var replyText = _stringConstant.DateFormatErrorMessage;
+            var replyText = string.Format(_stringConstant.DateFormatErrorMessage, dateFormat);
             var textJson = SlackReplyMethodMocking(slackLeave.ResponseUrl, replyText, _stringConstant.JsonContentString);
             await _slackRepository.LeaveRequestAsync(slackLeave);
             _mockHttpClient.Verify(x => x.PostAsync(slackLeave.ResponseUrl, textJson, _stringConstant.JsonContentString), Times.Once);

--- a/Slack.Automation/Promact.Erp.Web/NLog.config
+++ b/Slack.Automation/Promact.Erp.Web/NLog.config
@@ -47,6 +47,12 @@
      xsi:type="File"
      layout="Time : ${time} ${newline}Message : ${message} ${exception:format=tostring}${newline}----------------------------------------------------------------------------------------------------------------------------------------------------------------${newline}"
     fileName="NLog/nlog-slackRepository-${shortdate}.${level}.log"/>
+    
+    <target
+     name="clientRepository"
+     xsi:type="File"
+     layout="Time : ${time} ${newline}Message : ${message} ${exception:format=tostring}${newline}----------------------------------------------------------------------------------------------------------------------------------------------------------------${newline}"
+    fileName="NLog/nlog-clientRepository-${shortdate}.${level}.log"/>
     <!--<target xsi:type="ColoredConsole" 
             name="ColoredConsole" 
             layout="Time : ${time} ${newline}Message:${message} ${exception:format=tostring}${newline}">
@@ -63,6 +69,7 @@
     <logger name="TaskBotModule" minlevel="Trace" writeTo="taskBotModule" />
     <logger name="EmailService" minlevel="Trace" writeTo="emailService" />
     <logger name="SlackRepository" minlevel="Trace" writeTo="slackRepository" />
+    <logger name="ClientRepository" minlevel="Trace" writeTo="clientRepository" />
     <!--<logger name="ColoredConsole" minlevel="Trace" writeTo="ColoredConsole" />-->
     <logger name="*" level="Trace" writeTo="ownFile-web" />
     <logger name="*" level="Error" writeTo="ownFile-web" />


### PR DESCRIPTION
Fixes - #261 

**1. Client.cs** - added logger in ClientRepository of GetAttachmentAndSendToTLAndManagementAsync method
**2. SlackRepository.cs** - updated to details proper date time
**3. Nlog.Config** - added configuration for client repository
**4. SlackRepositoryTest.cs** - updated test case LeaveApplyForErrorDateFormatAsync