### PR TITLE
Removed slack channel dependency and added commands to link slack channel to OAuth project

### DIFF
--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
@@ -32,15 +32,15 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <param name="accessToken">user's access token from Promact OAuth Server</param>
         /// <returns>management details.List of object of User</returns>
         Task<List<User>> GetManagementUserNameAsync(string accessToken);
-        
-        
+
+
         /// <summary>
         /// Method to call an api from project oAuth server and get Project details of the given group - JJ
         /// </summary>
-        /// <param name="channelName">slack channel name</param>
+        /// <param name="projectId">Id of OAuth Project</param>
         /// <param name="accessToken">user's access token from Promact OAuth Server</param>
         /// <returns>object of ProjectAc</returns>
-        Task<ProjectAc> GetProjectDetailsAsync(string channelName, string accessToken);
+        Task<ProjectAc> GetProjectDetailsAsync(int projectId, string accessToken);
 
 
         /// <summary>

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
@@ -7,7 +7,6 @@ namespace Promact.Core.Repository.OauthCallsRepository
 {
     public interface IOauthCallsRepository
     {
-
         /// <summary>
         /// Method to call an api from project oAuth server and get Employee detail by their slack userId. - SS
         /// </summary>
@@ -44,15 +43,6 @@ namespace Promact.Core.Repository.OauthCallsRepository
 
 
         /// <summary>
-        /// This method is used to fetch list of users/employees of the given group name. - JJ
-        /// </summary>
-        /// <param name="channelName">slack channel name</param>
-        /// <param name="accessToken">user's access token from Promact OAuth Server</param>
-        /// <returns>list of object of User</returns>
-        Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken);
-
-
-        /// <summary>
         /// Method to call an api of oAuth server and get Casual leave allowed to user by user slackName. - SS
         /// </summary>
         /// <param name="userId">userId of user</param>
@@ -69,6 +59,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <returns>true if user has admin role else false</returns>
         Task<bool> UserIsAdminAsync(string userId, string accessToken);
 
+
         /// <summary>
         /// Method to get list of projects from oauth-server for an user
         /// </summary>
@@ -77,6 +68,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <returns></returns>
         Task<List<ProjectAc>> GetListOfProjectsEnrollmentOfUserByUserIdAsync(string userId, string accessToken);
 
+
         /// <summary>
         /// Method to get list of team member by project Id
         /// </summary>
@@ -84,5 +76,6 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <param name="accessToken">access token</param>
         /// <returns></returns>
         Task<List<User>> GetAllTeamMemberByProjectIdAsync(int projectId, string accessToken);
+
     }
 }

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
@@ -7,7 +7,6 @@ namespace Promact.Core.Repository.OauthCallsRepository
 {
     public interface IOauthCallsRepository
     {
-         
         /// <summary>
         /// Method to call an api from project oAuth server and get Employee detail by their slack userId. - SS
         /// </summary>
@@ -44,15 +43,6 @@ namespace Promact.Core.Repository.OauthCallsRepository
 
 
         /// <summary>
-        /// This method is used to fetch list of users/employees of the given group name. - JJ
-        /// </summary>
-        /// <param name="channelName">slack channel name</param>
-        /// <param name="accessToken">user's access token from Promact OAuth Server</param>
-        /// <returns>list of object of User</returns>
-        Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken);
-
-
-        /// <summary>
         /// Method to call an api of oAuth server and get Casual leave allowed to user by user slackName. - SS
         /// </summary>
         /// <param name="userId">userId of user</param>
@@ -69,6 +59,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <returns>true if user has admin role else false</returns>
         Task<bool> UserIsAdminAsync(string userId, string accessToken);
 
+
         /// <summary>
         /// Method to get list of projects from oauth-server for an user
         /// </summary>
@@ -77,6 +68,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <returns>list of project</returns>
         Task<List<ProjectAc>> GetListOfProjectsEnrollmentOfUserByUserIdAsync(string userId, string accessToken);
 
+
         /// <summary>
         /// Method to get list of team member by project Id
         /// </summary>
@@ -84,5 +76,6 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <param name="accessToken">access token</param>
         /// <returns>list of team members</returns>
         Task<List<User>> GetAllTeamMemberByProjectIdAsync(int projectId, string accessToken);
+
     }
 }

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/IOauthCallsRepository.cs
@@ -34,7 +34,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
 
 
         /// <summary>
-        /// Method to call an api from project oAuth server and get Project details of the given group - JJ
+        /// Method to call an api from project oAuth server and get Project details of the project id - JJ
         /// </summary>
         /// <param name="projectId">Id of OAuth Project</param>
         /// <param name="accessToken">user's access token from Promact OAuth Server</param>

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
@@ -89,11 +89,11 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <summary>
         /// Method to call an api from project oAuth server and get Project details of the given channel. - JJ 
         /// </summary>
-        /// <param name="channelName">slack channel name</param>
+        /// <param name="projectId">Id of OAuth Project</param>
         /// <returns>object of ProjectAc</returns>
-        public async Task<ProjectAc> GetProjectDetailsAsync(string channelName, string accessToken)
+        public async Task<ProjectAc> GetProjectDetailsAsync(int projectId, string accessToken)
         {
-            var requestUrl = channelName;
+            var requestUrl = projectId.ToString();
             var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
             ProjectAc project = new ProjectAc();
             if (!string.IsNullOrEmpty(response))

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
@@ -93,8 +93,8 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <returns>object of ProjectAc</returns>
         public async Task<ProjectAc> GetProjectDetailsAsync(int projectId, string accessToken)
         {
-            var requestUrl = projectId.ToString();
-            var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
+            string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, projectId.ToString());
+            string response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
             ProjectAc project = new ProjectAc();
             if (!string.IsNullOrEmpty(response))
             {
@@ -104,23 +104,23 @@ namespace Promact.Core.Repository.OauthCallsRepository
         }
 
 
-        /// <summary>
-        /// This method is used to fetch list of users/employees of the given channel name from OAuth server. - JJ
-        /// </summary>
-        /// <param name="channelName">slack channel name</param>
-        /// <param name="accessToken">user's access token from Promact OAuth Server</param>
-        /// <returns>list of object of User</returns>
-        public async Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken)
-        {
-            string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UsersDetailByChannelNameUrl, channelName);
-            string response = await _httpClientService.GetAsync(_stringConstant.UserUrl, requestUrl, accessToken);
-            List<User> users = new List<User>();
-            if (!string.IsNullOrEmpty(response))
-            {
-                users = JsonConvert.DeserializeObject<List<User>>(response);
-            }
-            return users;
-        }
+        ///// <summary>
+        ///// This method is used to fetch list of users/employees of the given channel name from OAuth server. - JJ
+        ///// </summary>
+        ///// <param name="channelName">slack channel name</param>
+        ///// <param name="accessToken">user's access token from Promact OAuth Server</param>
+        ///// <returns>list of object of User</returns>
+        //public async Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken)
+        //{
+        //    string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UsersDetailByChannelNameUrl, channelName);
+        //    string response = await _httpClientService.GetAsync(_stringConstant.UserUrl, requestUrl, accessToken);
+        //    List<User> users = new List<User>();
+        //    if (!string.IsNullOrEmpty(response))
+        //    {
+        //        users = JsonConvert.DeserializeObject<List<User>>(response);
+        //    }
+        //    return users;
+        //}
 
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
             List<ProjectAc> projects = new List<ProjectAc>();
             var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, userId);
             var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
-            if(response != null)
+            if (response != null)
             {
                 projects = JsonConvert.DeserializeObject<List<ProjectAc>>(response);
             }
@@ -189,12 +189,14 @@ namespace Promact.Core.Repository.OauthCallsRepository
             List<User> teamMembers = new List<User>();
             var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UserDetailsUrl, projectId);
             var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
-            if(response != null)
+            if (response != null)
             {
                 teamMembers = JsonConvert.DeserializeObject<List<User>>(response);
             }
             return teamMembers;
         }
+        
+
         #endregion
     }
 }

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
@@ -87,7 +87,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
 
 
         /// <summary>
-        /// Method to call an api from project oAuth server and get Project details of the given channel. - JJ 
+        /// Method to call an api from project oAuth server and get Project details of the given project id. - JJ 
         /// </summary>
         /// <param name="projectId">Id of OAuth Project</param>
         /// <returns>object of ProjectAc</returns>
@@ -102,26 +102,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
             }
             return project;
         }
-
-
-        ///// <summary>
-        ///// This method is used to fetch list of users/employees of the given channel name from OAuth server. - JJ
-        ///// </summary>
-        ///// <param name="channelName">slack channel name</param>
-        ///// <param name="accessToken">user's access token from Promact OAuth Server</param>
-        ///// <returns>list of object of User</returns>
-        //public async Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken)
-        //{
-        //    string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UsersDetailByChannelNameUrl, channelName);
-        //    string response = await _httpClientService.GetAsync(_stringConstant.UserUrl, requestUrl, accessToken);
-        //    List<User> users = new List<User>();
-        //    if (!string.IsNullOrEmpty(response))
-        //    {
-        //        users = JsonConvert.DeserializeObject<List<User>>(response);
-        //    }
-        //    return users;
-        //}
-
+                   
 
         /// <summary>
         /// Method to call an api of oAuth server and get Casual leave allowed to user by user slackName. - SS

--- a/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/OauthCallsRepository/OauthCallsRepository.cs
@@ -93,8 +93,8 @@ namespace Promact.Core.Repository.OauthCallsRepository
         /// <returns>object of ProjectAc</returns>
         public async Task<ProjectAc> GetProjectDetailsAsync(int projectId, string accessToken)
         {
-            var requestUrl = projectId.ToString();
-            var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
+            string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, projectId.ToString());
+            string response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
             ProjectAc project = new ProjectAc();
             if (!string.IsNullOrEmpty(response))
             {
@@ -104,23 +104,23 @@ namespace Promact.Core.Repository.OauthCallsRepository
         }
 
 
-        /// <summary>
-        /// This method is used to fetch list of users/employees of the given channel name from OAuth server. - JJ
-        /// </summary>
-        /// <param name="channelName">slack channel name</param>
-        /// <param name="accessToken">user's access token from Promact OAuth Server</param>
-        /// <returns>list of object of User</returns>
-        public async Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken)
-        {
-            string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UsersDetailByChannelNameUrl, channelName);
-            string response = await _httpClientService.GetAsync(_stringConstant.UserUrl, requestUrl, accessToken);
-            List<User> users = new List<User>();
-            if (!string.IsNullOrEmpty(response))
-            {
-                users = JsonConvert.DeserializeObject<List<User>>(response);
-            }
-            return users;
-        }
+        ///// <summary>
+        ///// This method is used to fetch list of users/employees of the given channel name from OAuth server. - JJ
+        ///// </summary>
+        ///// <param name="channelName">slack channel name</param>
+        ///// <param name="accessToken">user's access token from Promact OAuth Server</param>
+        ///// <returns>list of object of User</returns>
+        //public async Task<List<User>> GetUsersByChannelNameAsync(string channelName, string accessToken)
+        //{
+        //    string requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.UsersDetailByChannelNameUrl, channelName);
+        //    string response = await _httpClientService.GetAsync(_stringConstant.UserUrl, requestUrl, accessToken);
+        //    List<User> users = new List<User>();
+        //    if (!string.IsNullOrEmpty(response))
+        //    {
+        //        users = JsonConvert.DeserializeObject<List<User>>(response);
+        //    }
+        //    return users;
+        //}
 
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace Promact.Core.Repository.OauthCallsRepository
             List<ProjectAc> projects = new List<ProjectAc>();
             var requestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, userId);
             var response = await _httpClientService.GetAsync(_stringConstant.ProjectUrl, requestUrl, accessToken);
-            if(response != null)
+            if (response != null)
             {
                 projects = JsonConvert.DeserializeObject<List<ProjectAc>>(response);
             }
@@ -195,6 +195,8 @@ namespace Promact.Core.Repository.OauthCallsRepository
             }
             return teamMembers;
         }
+        
+
         #endregion
     }
 }

--- a/Slack.Automation/Promact.Core.Repository/Promact.Core.Repository.csproj
+++ b/Slack.Automation/Promact.Core.Repository/Promact.Core.Repository.csproj
@@ -178,6 +178,8 @@
     <Compile Include="ScrumReportRepository\ScrumReportRepository.cs" />
     <Compile Include="ScrumRepository\IScrumBotRepository.cs" />
     <Compile Include="ScrumRepository\ScrumBotRepository.cs" />
+    <Compile Include="ScrumSetUpRepository\IScrumSetUpRepository.cs" />
+    <Compile Include="ScrumSetUpRepository\ScrumSetUpRepository.cs" />
     <Compile Include="ServiceRepository\IServiceRepository.cs" />
     <Compile Include="ServiceRepository\ServiceRepository.cs" />
     <Compile Include="SlackChannelRepository\ISlackChannelRepository.cs" />

--- a/Slack.Automation/Promact.Core.Repository/Promact.Core.Repository.csproj
+++ b/Slack.Automation/Promact.Core.Repository/Promact.Core.Repository.csproj
@@ -180,6 +180,8 @@
     <Compile Include="ScrumReportRepository\ScrumReportRepository.cs" />
     <Compile Include="ScrumRepository\IScrumBotRepository.cs" />
     <Compile Include="ScrumRepository\ScrumBotRepository.cs" />
+    <Compile Include="ScrumSetUpRepository\IScrumSetUpRepository.cs" />
+    <Compile Include="ScrumSetUpRepository\ScrumSetUpRepository.cs" />
     <Compile Include="ServiceRepository\IServiceRepository.cs" />
     <Compile Include="ServiceRepository\ServiceRepository.cs" />
     <Compile Include="SlackChannelRepository\ISlackChannelRepository.cs" />

--- a/Slack.Automation/Promact.Core.Repository/ScrumReportRepository/ScrumReportRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumReportRepository/ScrumReportRepository.cs
@@ -49,7 +49,7 @@ namespace Promact.Core.Repository.ScrumReportRepository
             //If logged user is an employee it will return only his scrum answers
             if (loginUser.Role.Equals(_stringConstant.Employee))
             {
-                foreach (var user in project.ApplicationUsers)
+                foreach (var user in project.Users)
                 {
                     if (user.Id.Equals(loginUser.Id))
                     {
@@ -61,7 +61,7 @@ namespace Promact.Core.Repository.ScrumReportRepository
             //If logged user is admin or teamleader it will return scrum answers for the entire team
             else
             {
-                foreach (var user in project.ApplicationUsers)
+                foreach (var user in project.Users)
                 {
                     EmployeeScrumDetails employeeScrumDetail = await AssignAnswersAsync(scrum, scrumDate, user);
                     employeeScrumDetails.Add(employeeScrumDetail);
@@ -148,7 +148,7 @@ namespace Promact.Core.Repository.ScrumReportRepository
                     List<ProjectAc> employeeProjects = new List<ProjectAc>();
                     foreach (var project in projects)
                     {
-                        foreach (var user in project.ApplicationUsers)
+                        foreach (var user in project.Users)
                         {
                             if (user.Id == loginUser.Id)
                             {

--- a/Slack.Automation/Promact.Core.Repository/ScrumReportRepository/ScrumReportRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumReportRepository/ScrumReportRepository.cs
@@ -57,7 +57,7 @@ namespace Promact.Core.Repository.ScrumReportRepository
             }
             else
             {
-                foreach (var user in project.ApplicationUsers)
+                foreach (var user in project.Users)
                 {
                     EmployeeScrumDetails employeeScrumDetail = await AssignAnswersAsync(scrum, scrumDate, user);
                     employeeScrumDetails.Add(employeeScrumDetail);

--- a/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
@@ -108,7 +108,7 @@ namespace Promact.Core.Repository.ScrumRepository
 
                 if (accessToken != null)
                 {
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelDetail.Name, accessToken);
+                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync((int)slackChannelDetail.ProjectId, accessToken);
                     if (project?.Id > 0)
                     {
                         Scrum scrum = _scrumDataRepository.FirstOrDefault(x => x.ProjectId == project.Id && x.ScrumDate == date);
@@ -197,14 +197,14 @@ namespace Promact.Core.Repository.ScrumRepository
                         {
                             _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
                             replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
-                                message, slackChannelId, slackChannelDetail.Name, slackUserDetail.UserId);
+                                message, slackChannelId, slackChannelDetail.ProjectId, slackUserDetail.UserId);
                         }
                     }
                     else  //all other texts
                     {
                         _logger.Debug("AddScrumAnswerAsync method");
                         replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
-                            slackChannelId, slackChannelDetail.Name, slackUserDetail.UserId);
+                            slackChannelId, slackChannelDetail.ProjectId, slackUserDetail.UserId);
                     }
                 }
                 else   //channel is not registered in the database
@@ -444,10 +444,10 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="message">the message that interacting user sends</param>
         /// <param name="slackChannelId">slack channel id from which message is send</param>
-        /// <param name="slackChannelName">slack channel name from which the message has been send</param>
+        /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <returns>the next question statement</returns>
-        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, string slackChannelId, string slackChannelName, string slackUserId)
+        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, string slackChannelId, int projectId, string slackUserId)
         {
             string reply = string.Empty;
             //today's scrum of the channel 
@@ -461,8 +461,8 @@ namespace Promact.Core.Repository.ScrumRepository
                     //list of scrum questions. Type = BotQuestionType.Scrum
                     List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
                     //users of the given channel name fetched from the oauth server
-                    List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
+                    List<User> users = await GetOAuthUsersAsync(projectId, accessToken);
+                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
                     ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
                     //scrumStatus could be anything like the project is in-active
                     if (scrumStatus == ScrumStatus.OnGoing)

--- a/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
@@ -106,7 +106,7 @@ namespace Promact.Core.Repository.ScrumRepository
 
                 if (accessToken != null)
                 {
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelDetail.Name, accessToken);
+                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync((int)slackChannelDetail.ProjectId, accessToken);
                     if (project?.Id > 0)
                     {
                         Scrum scrum = _scrumDataRepository.FirstOrDefault(x => x.ProjectId == project.Id && x.ScrumDate == date);
@@ -189,14 +189,14 @@ namespace Promact.Core.Repository.ScrumRepository
                         {
                             _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
                             replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
-                                message, slackChannelId, slackChannelDetail.Name, slackUserDetail.UserId);
+                                message, slackChannelId, slackChannelDetail.ProjectId, slackUserDetail.UserId);
                         }
                     }
                     else  //all other texts
                     {
                         _logger.Debug("AddScrumAnswerAsync method");
                         replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
-                            slackChannelId, slackChannelDetail.Name, slackUserDetail.UserId);
+                            slackChannelId, slackChannelDetail.ProjectId, slackUserDetail.UserId);
                     }
                 }
                 else   //channel is not registered in the database
@@ -441,10 +441,10 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="message">the message that interacting user sends</param>
         /// <param name="slackChannelId">slack channel id from which message is send</param>
-        /// <param name="slackChannelName">slack channel name from which the message has been send</param>
+        /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <returns>the next question statement</returns>
-        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, string slackChannelId, string slackChannelName, string slackUserId)
+        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, string slackChannelId, int projectId, string slackUserId)
         {
             string reply = string.Empty;
             //today's scrum of the channel 
@@ -458,8 +458,8 @@ namespace Promact.Core.Repository.ScrumRepository
                     //list of scrum questions. Type = BotQuestionType.Scrum
                     List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
                     //users of the given channel name fetched from the oauth server
-                    List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
+                    List<User> users = await GetOAuthUsersAsync(projectId, accessToken);
+                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
                     ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
                     //scrumStatus could be anything like the project is in-active
                     if (scrumStatus == ScrumStatus.OnGoing)

--- a/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
@@ -16,6 +16,7 @@ using Promact.Core.Repository.AttachmentRepository;
 using Promact.Core.Repository.BotQuestionRepository;
 using Promact.Core.Repository.BaseRepository;
 using NLog;
+using Promact.Core.Repository.ScrumSetUpRepository;
 
 namespace Promact.Core.Repository.ScrumRepository
 {
@@ -36,9 +37,9 @@ namespace Promact.Core.Repository.ScrumRepository
         private readonly ISlackUserRepository _slackUserDetailRepository;
         private readonly IStringConstantRepository _stringConstant;
         private readonly IBotQuestionRepository _botQuestionRepository;
+        private readonly IScrumSetUpRepository _scrumSetUpRepository;
         private readonly IMapper _mapper;
         private readonly ILogger _logger;
-
 
         #endregion
 
@@ -52,7 +53,7 @@ namespace Promact.Core.Repository.ScrumRepository
             IRepository<SlackUserDetails> slackUserDetailsDataRepository,
             ISlackChannelRepository slackChannelRepository, IOauthCallsRepository oauthCallsRepository,
             ISlackUserRepository slackUserDetailRepository, IStringConstantRepository stringConstant,
-            IBotQuestionRepository botQuestionRepository, IMapper mapper,
+            IBotQuestionRepository botQuestionRepository, IMapper mapper, IScrumSetUpRepository scrumSetUpRepository,
             IRepository<ApplicationUser> applicationUser, IAttachmentRepository attachmentRepository)
             : base(applicationUser, attachmentRepository)
         {
@@ -68,6 +69,7 @@ namespace Promact.Core.Repository.ScrumRepository
             _stringConstant = stringConstant;
             _botQuestionRepository = botQuestionRepository;
             _applicationUser = applicationUser;
+            _scrumSetUpRepository = scrumSetUpRepository;
             _mapper = mapper;
         }
 
@@ -145,58 +147,80 @@ namespace Promact.Core.Repository.ScrumRepository
                 }
                 else if (slackChannelDetail != null)
                 {
-                    //commands could be "scrum halt" or "scrum resume"
-                    if (String.Compare(message, _stringConstant.ScrumHalt, StringComparison.OrdinalIgnoreCase) == 0 ||
-                        String.Compare(message, _stringConstant.ScrumResume, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (String.Compare(messageArray[0], _stringConstant.Link, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        String.Compare(messageArray[0], _stringConstant.Unlink, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        String.Compare(message, _stringConstant.ListLinks, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        _logger.Debug("Scrum command is :" + message);
-                        replyText = await ScrumAsync(slackChannelId, slackChannelDetail.Name, slackUserDetail.Name, messageArray[1].ToLower(), slackUserDetail.UserId);
+                        replyText = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(slackUserId, slackChannelDetail, message);
+                        if (string.IsNullOrEmpty(replyText))
+                            replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message, slackChannelDetail.ProjectId, slackUserId);
                     }
-                    //a particular user is on leave. command would be like "leave <@userId>"
-                    else if (((String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0) || (String.Compare(messageArray[0], _stringConstant.Start, StringComparison.OrdinalIgnoreCase) == 0)) && messageArray.Length == 2)
+                    else
                     {
-                        _logger.Debug("Scrum command is leave or start");
-                        //"<@".Length is 2
-                        int fromIndex = message.IndexOf("<@", StringComparison.Ordinal) + 2;
-                        int toIndex = message.LastIndexOf(">", StringComparison.Ordinal);
-                        if (toIndex > 0 && fromIndex > 1)
+                        #region code specific to scrum
+
+                        if (slackChannelDetail.ProjectId != null)
                         {
-                            //the slack userId is fetched
-                            string applicantId = message.Substring(fromIndex, toIndex - fromIndex);
-                            _logger.Debug("Scrum command is leave or start. User mentioned is :" + applicantId);
-                            if (String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0)
+                            //commands could be "scrum halt" or "scrum resume"
+                            if (String.Compare(message, _stringConstant.ScrumHalt, StringComparison.OrdinalIgnoreCase) == 0 ||
+                                String.Compare(message, _stringConstant.ScrumResume, StringComparison.OrdinalIgnoreCase) == 0)
                             {
-                                _logger.Debug("Scrum command is leave");
-                                //fetch the user of the given userId
-                                SlackUserDetailAc applicantDetailsAc = await _slackUserDetailRepository.GetByIdAsync(applicantId);
-                                replyText = applicantDetailsAc != null ? await LeaveAsync(slackChannelId, slackChannelDetail.Name, slackUserDetail.Name, slackUserDetail.UserId, applicantDetailsAc.Name, applicantId) : _stringConstant.NotAUser;
+                                _logger.Debug("Scrum command is :" + message);
+                                replyText = await ScrumAsync((int)slackChannelDetail.ProjectId, slackUserDetail.Name, messageArray[1].ToLower(), slackUserDetail.UserId);
                             }
-                            else
+                            //a particular user is on leave. command would be like "leave <@userId>"
+                            else if (((String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0) || (String.Compare(messageArray[0], _stringConstant.Start, StringComparison.OrdinalIgnoreCase) == 0)) && messageArray.Length == 2)
                             {
-                                if (String.Compare(applicantId, scrumBotId, StringComparison.Ordinal) == 0)
+                                _logger.Debug("Scrum command is leave or start");
+                                //"<@".Length is 2
+                                int fromIndex = message.IndexOf("<@", StringComparison.Ordinal) + 2;
+                                int toIndex = message.LastIndexOf(">", StringComparison.Ordinal);
+                                if (toIndex > 0 && fromIndex > 1)
                                 {
-                                    _logger.Debug("Scrum command is start");
-                                    replyText = await ScrumAsync(slackChannelId, slackChannelDetail.Name, slackUserDetail.Name, messageArray[0].ToLower(), slackUserDetail.UserId);
+                                    //the slack userId is fetched
+                                    string applicantId = message.Substring(fromIndex, toIndex - fromIndex);
+                                    _logger.Debug("Scrum command is leave or start. User mentioned is :" + applicantId);
+                                    if (String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0)
+                                    {
+                                        _logger.Debug("Scrum command is leave");
+                                        //fetch the user of the given userId
+                                        SlackUserDetailAc applicantDetailsAc = await _slackUserDetailRepository.GetByIdAsync(applicantId);
+                                        replyText = applicantDetailsAc != null ? await LeaveAsync((int)slackChannelDetail.ProjectId, slackUserDetail.Name, slackUserDetail.UserId, applicantDetailsAc.Name, applicantId) : _stringConstant.NotAUser;
+                                    }
+                                    else
+                                    {
+                                        if (String.Compare(applicantId, scrumBotId, StringComparison.Ordinal) == 0)
+                                        {
+                                            _logger.Debug("Scrum command is start");
+                                            replyText = await ScrumAsync((int)slackChannelDetail.ProjectId, slackUserDetail.Name, messageArray[0].ToLower(), slackUserDetail.UserId);
+                                        }
+                                        else
+                                        {
+                                            _logger.Debug("Invalid start command");
+                                            replyText = string.Format(_stringConstant.InValidStartCommand, scrumBotId);
+                                        }
+                                    }
                                 }
-                                else
+                                else //when command would be like "leave <@>"
                                 {
-                                    _logger.Debug("Invalid start command");
-                                    replyText = string.Format(_stringConstant.InValidStartCommand, scrumBotId);
+                                    _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
+                                    replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
+                                        message, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
                                 }
+                            }
+                            else  //all other texts
+                            {
+                                _logger.Debug("AddScrumAnswerAsync method");
+                                replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
+                                     (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
                             }
                         }
-                        else //when command would be like "leave <@>"
+                        else
                         {
-                            _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
-                            replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
-                                message, slackChannelId, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
+                            replyText = _stringConstant.ProjectChannelNotLinked;
                         }
-                    }
-                    else  //all other texts
-                    {
-                        _logger.Debug("AddScrumAnswerAsync method");
-                        replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
-                            slackChannelId, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
+
+                        #endregion
                     }
                 }
                 else   //channel is not registered in the database
@@ -206,7 +230,7 @@ namespace Promact.Core.Repository.ScrumRepository
                         String.Compare(messageArray[1], _stringConstant.Channel, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         _logger.Debug("AddChannelManuallyAsync method");
-                        replyText = await AddChannelManuallyAsync(messageArray[2], slackChannelId, slackUserDetail.UserId);
+                        replyText = await _scrumSetUpRepository.AddChannelManuallyAsync(messageArray[2], slackChannelId, slackUserDetail.UserId);
                     }
                     //If any of the commands which scrum bot recognizes is encountered
                     else if ((((String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0) || (String.Compare(messageArray[0], _stringConstant.Start, StringComparison.OrdinalIgnoreCase) == 0)) &&
@@ -237,7 +261,7 @@ namespace Promact.Core.Repository.ScrumRepository
             return replyText;
         }
 
-
+                
         #region Temporary Scrum Details
 
 
@@ -423,9 +447,9 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <summary>
         /// Fetch today's scrum - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="projectId">slack channel id from which message is send</param>
         /// <returns>Object of Scrum</returns>
-        private async Task<Scrum> GetScrumAsync(string slackChannelId)
+        private async Task<Scrum> GetScrumAsync(int projectId)
         {
             DateTime date = DateTime.UtcNow.Date;
             var scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => String.Compare(x.SlackChannelId, slackChannelId, StringComparison.OrdinalIgnoreCase) == 0 &&
@@ -440,100 +464,79 @@ namespace Promact.Core.Repository.ScrumRepository
         /// </summary>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="message">the message that interacting user sends</param>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <returns>the next question statement</returns>
-        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, string slackChannelId, int projectId, string slackUserId)
+        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, int? projectId, string slackUserId)
         {
-            string reply = string.Empty;
-            //today's scrum of the channel 
-            Scrum scrum = await GetScrumAsync(slackChannelId);
-            if (scrum != null && scrum.IsOngoing && !scrum.IsHalted)
+            if (projectId != null)
             {
-                // get access token of user for promact oauth server
-                var accessToken = await GetAccessToken(slackUserId);
-                if (accessToken != null)
+                string reply = string.Empty;
+                //today's scrum of the channel 
+                Scrum scrum = await GetScrumAsync((int)projectId);
+                if (scrum != null && scrum.IsOngoing && !scrum.IsHalted)
                 {
-                    //list of scrum questions. Type = BotQuestionType.Scrum
-                    List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
-                    //users of the given channel name fetched from the oauth server
-                    List<User> users = await GetOAuthUsersAsync(projectId, accessToken);
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
-                    ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
-                    //scrumStatus could be anything like the project is in-active
-                    if (scrumStatus == ScrumStatus.OnGoing)
+                    // get access token of user for promact oauth server
+                    var accessToken = await GetAccessToken(slackUserId);
+                    if (accessToken != null)
                     {
-                        //status would be empty if the interacting user is same as the expected user.
-                        string status = await ExpectedUserAsync(scrum.Id, questions, users, slackUserName, slackUserId, scrum.ProjectId);
-                        if (string.IsNullOrEmpty(status))
+                        //list of scrum questions. Type = BotQuestionType.Scrum
+                        List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
+                        ProjectAc project = await GetOAuthProjectAsync((int)projectId, accessToken);
+                        //users of the given channel name fetched from the oauth server
+                        List<User> users = project?.Users;
+                        ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions);
+                        //scrumStatus could be anything like the project is in-active
+                        if (scrumStatus == ScrumStatus.OnGoing)
                         {
-                            TemporaryScrumDetails temporaryScrumDetails = await FetchTemporaryScrumDetailsAsync(scrum.Id);
-                            User user = users.First(x => x.SlackUserId == temporaryScrumDetails.SlackUserId);
-                            if (temporaryScrumDetails.QuestionId != null)
+                            //status would be empty if the interacting user is same as the expected user.
+                            string status = await ExpectedUserAsync(scrum.Id, questions, users, slackUserName, slackUserId, scrum.ProjectId);
+                            if (string.IsNullOrEmpty(status))
                             {
-                                AddAnswer(scrum.Id, (int)temporaryScrumDetails.QuestionId, user.Id, message, ScrumAnswerStatus.Answered);
-                                await _scrumAnswerDataRepository.SaveChangesAsync();
-                            }
-                            else
-                                return _stringConstant.AnswerNotRecorded;
+                                TemporaryScrumDetails temporaryScrumDetails = await FetchTemporaryScrumDetailsAsync(scrum.Id);
+                                User user = users.First(x => x.SlackUserId == temporaryScrumDetails.SlackUserId);
+                                if (temporaryScrumDetails.QuestionId != null)
+                                {
+                                    AddAnswer(scrum.Id, (int)temporaryScrumDetails.QuestionId, user.Id, message, ScrumAnswerStatus.Answered);
+                                    await _scrumAnswerDataRepository.SaveChangesAsync();
+                                }
+                                else
+                                    return _stringConstant.AnswerNotRecorded;
 
-                            //update the details in temporary table 
-                            await UpdateTemporaryScrumDetailsAsync(slackUserId, scrum.Id, users, null);
-                            //get the next question
-                            reply = await GetQuestionAsync(scrum.Id, questions, users, scrum.ProjectId);
+                                //update the details in temporary table 
+                                await UpdateTemporaryScrumDetailsAsync(slackUserId, scrum.Id, users, null);
+                                //get the next question
+                                reply = await GetQuestionAsync(scrum.Id, questions, users, scrum.ProjectId);
+                            }
+                            //the user interacting is not the expected user
+                            else
+                                reply = status;
                         }
-                        //the user interacting is not the expected user
                         else
-                            reply = status;
+                            reply = ReplyStatusofScrumToClient(scrumStatus);
                     }
                     else
-                        reply = ReplyStatusofScrumToClient(scrumStatus);
+                        // if user doesn't exist then this message will be shown to user
+                        reply = _stringConstant.YouAreNotInExistInOAuthServer;
                 }
-                else
-                    // if user doesn't exist then this message will be shown to user
-                    reply = _stringConstant.YouAreNotInExistInOAuthServer;
+                return reply;
             }
-            return reply;
-        }
-
-
-        /// <summary>
-        /// Get users of the OAuth project corresponding to the given slackChannelName - JJ
-        /// </summary>
-        /// <param name="slackChannelName">slack channel name from which the message has been send</param>
-        /// <param name="accessToken">Access token of the interacting user</param>
-        /// <returns>list of object of User</returns>
-        private async Task<List<User>> GetOAuthUsersAsync(string slackChannelName, string accessToken)
-        {
-            //Users of the OAuth project corresponding to the given slackChannelName
-            List<User> users = await _oauthCallsRepository.GetUsersByChannelNameAsync(slackChannelName, accessToken);
-            var ids = users.Select(a => a.Id);
-            //Application Users in Erp who are members of the OAuth project corresponding to the given slackChannelName 
-            var appUsers = _applicationUser.FetchAsync(x => ids.Contains(x.Id)).Result
-                .Select(y => new { Id = y.Id, SlackUserId = y.SlackUserId }).ToList();
-            //assign SlackUserId 
-            users.ForEach(x =>
-            {
-                x.SlackUserId = appUsers.FirstOrDefault(y => y.Id == x.Id)?.SlackUserId;
-            });
-            return users.Where(x => !string.IsNullOrEmpty(x.SlackUserId)).ToList();
+            return _stringConstant.ProjectChannelNotLinked;
         }
 
 
         /// <summary>
         /// This method will be called when the keyword "scrum time" or "scrum halt" or "scrum resume" is encountered. - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="parameter">the keyword(second word) send by the user</param>      
         /// <param name="slackUserId">slack userId of the interacting user</param>
         /// <returns>The question or the status of the scrum</returns>
-        private async Task<string> ScrumAsync(string slackChannelId, int projectId, string slackUserName, string parameter, string slackUserId)
+        private async Task<string> ScrumAsync(int projectId, string slackUserName, string parameter, string slackUserId)
         {
             //because any command outside the scrum time must not be entertained except with the replies like "scrum is concluded","scrum has not started" or "scrum has not started".
-            Scrum scrum = await GetScrumAsync(slackChannelId);
+            Scrum scrum = await GetScrumAsync(projectId);
             ScrumActions scrumCommand = (ScrumActions)Enum.Parse(typeof(ScrumActions), parameter);
             if (scrumCommand == ScrumActions.start || scrum != null)
             {
@@ -543,53 +546,57 @@ namespace Promact.Core.Repository.ScrumRepository
                     var accessToken = await GetAccessToken(slackUserId);
                     if (accessToken != null)
                     {
-                        List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                        ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
-                        ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, null, slackChannelId);
-
-                        if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
+                        ProjectAc project = await GetOAuthProjectAsync(projectId, accessToken);
+                        List<User> users = project?.Users;
+                        ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, null);
+                        if (users?.Count > 0)
                         {
-                            switch (scrumCommand)
+                            if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
                             {
-                                case ScrumActions.halt:
-                                    //keyword encountered is "scrum halt"
-                                    return await ScrumHaltAsync(scrum, scrumStatus);
-                                case ScrumActions.resume:
-                                    //keyword encountered is "scrum resume"
-                                    return await ScrumResumeAsync(scrum, users, scrumStatus);
-                                case ScrumActions.start:
-                                    //keyword encountered is "start <@botId>"
-                                    return await StartScrumAsync(slackChannelId, users, project, scrumStatus);
-                                default:
-                                    return string.Empty;
+                                switch (scrumCommand)
+                                {
+                                    case ScrumActions.halt:
+                                        //keyword encountered is "scrum halt"
+                                        return await ScrumHaltAsync(scrum, scrumStatus);
+                                    case ScrumActions.resume:
+                                        //keyword encountered is "scrum resume"
+                                        return await ScrumResumeAsync(scrum, users, scrumStatus);
+                                    case ScrumActions.start:
+                                        //keyword encountered is "start <@botId>"
+                                        return await StartScrumAsync(projectId, users, project, scrumStatus);
+                                    default:
+                                        return string.Empty;
+                                }
                             }
-                        }
-                        //if user is in-active
-                        string returnMessage;
-                        switch (scrumStatus)
-                        {
-                            case ScrumStatus.Halted:
-                                returnMessage = (scrumCommand == ScrumActions.resume ? _stringConstant.ScrumCannotBeResumed : string.Empty) + string.Format(_stringConstant.InActiveInOAuth, slackUserName);
-                                break;
-                            //scrum is in progress
-                            case ScrumStatus.OnGoing:
-                                List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
-                                if (scrum != null)
-                                    returnMessage = await GetReplyToUserAsync(users, project.Id, scrum.Id, slackUserId, slackUserName, questions);
-                                else
-                                    return _stringConstant.ErrorMsgNewPrivateChannel;
-                                if (scrumCommand == ScrumActions.resume)
-                                    returnMessage = _stringConstant.ScrumNotHalted + Environment.NewLine + returnMessage;
-                                else if (scrumCommand == ScrumActions.halt)
-                                    returnMessage = _stringConstant.ScrumCannotBeHalted + Environment.NewLine + returnMessage;
-                                break;
+                            //if user is in-active
+                            string returnMessage;
+                            switch (scrumStatus)
+                            {
+                                case ScrumStatus.Halted:
+                                    returnMessage = (scrumCommand == ScrumActions.resume ? _stringConstant.ScrumCannotBeResumed : string.Empty) + string.Format(_stringConstant.InActiveInOAuth, slackUserName);
+                                    break;
+                                //scrum is in progress
+                                case ScrumStatus.OnGoing:
+                                    List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
+                                    if (scrum != null)
+                                        returnMessage = await GetReplyToUserAsync(users, project.Id, scrum.Id, slackUserId, slackUserName, questions);
+                                    else
+                                        return _stringConstant.ErrorMsgNewPrivateChannel;
+                                    if (scrumCommand == ScrumActions.resume)
+                                        returnMessage = _stringConstant.ScrumNotHalted + Environment.NewLine + returnMessage;
+                                    else if (scrumCommand == ScrumActions.halt)
+                                        returnMessage = _stringConstant.ScrumCannotBeHalted + Environment.NewLine + returnMessage;
+                                    break;
 
-                            //for all other status of the scrum
-                            default:
-                                returnMessage = ReplyStatusofScrumToClient(scrumStatus);
-                                break;
+                                //for all other status of the scrum
+                                default:
+                                    returnMessage = ReplyStatusofScrumToClient(scrumStatus);
+                                    break;
+                            }
+                            return returnMessage;
                         }
-                        return returnMessage;
+                        else
+                            return _stringConstant.NoEmployeeFound;
                     }
                     return _stringConstant.YouAreNotInExistInOAuthServer;
                 }
@@ -602,19 +609,18 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <summary>
         /// This method will be called when the keyword "leave @username" is received as reply from a channel member. - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <param name="applicant">slack user name of the user who is being marked on leave</param>
         /// <param name="applicantId">slack user id of the user who is being marked on leave</param>
         /// <returns>Question to the next person or other scrum status</returns>
-        private async Task<string> LeaveAsync(string slackChannelId, int projectId, string slackUserName, string slackUserId, string applicant, string applicantId)
+        private async Task<string> LeaveAsync(int projectId, string slackUserName, string slackUserId, string applicant, string applicantId)
         {
             string returnMsg;
             //we will have to check whether the scrum is on going or not before calling FetchScrumStatus()
             //because any command outside the scrum time must not be entertained except with the replies like "scrum is concluded","scrum has not started" or "scrum has not started".
-            Scrum scrum = await GetScrumAsync(slackChannelId);
+            Scrum scrum = await GetScrumAsync(projectId);
             if (scrum != null)
             {
                 if (scrum.IsOngoing)
@@ -626,10 +632,9 @@ namespace Promact.Core.Repository.ScrumRepository
                         if (accessToken != null)
                         {
                             List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
-                            List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                            ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
-
-                            ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
+                            ProjectAc project = await GetOAuthProjectAsync(projectId, accessToken);
+                            List<User> users = project?.Users;
+                            ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions);
                             if (scrumStatus == ScrumStatus.OnGoing)
                             {
                                 if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
@@ -658,66 +663,6 @@ namespace Promact.Core.Repository.ScrumRepository
 
 
         /// <summary>
-        /// Used to add channel manually by command "add channel channelname". - JJ
-        /// </summary>
-        /// <param name="slackChannelName">slack channel name from which message is send</param>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
-        /// <param name="slackUserId">slack user id of interacting user</param>
-        /// <returns>status message</returns>
-        private async Task<string> AddChannelManuallyAsync(string slackChannelName, string slackChannelId, string slackUserId)
-        {
-            string returnMsg;
-            //Checks whether channelId starts with "G". This is done inorder to make sure that only private channels are added manually
-            if (IsPrivateChannel(slackChannelId))
-            {
-                //// get access token of user for promact oauth server
-                //var accessToken = await GetAccessToken(slackUserId);
-                //if (accessToken != null)
-                //{
-                //    //get the project details of the given channel name
-                //    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
-                //    //add channel details only if the channel has been registered as project in OAuth server
-                //    if (project?.Id > 0)
-                //    {
-                //        if (project.IsActive)
-                //        {
-                SlackChannelDetails slackChannelDetails = new SlackChannelDetails();
-                slackChannelDetails.ChannelId = slackChannelId;
-                slackChannelDetails.CreatedOn = DateTime.UtcNow;
-                slackChannelDetails.Deleted = false;
-                slackChannelDetails.Name = slackChannelName;
-                await _slackChannelRepository.AddSlackChannelAsync(slackChannelDetails);
-                returnMsg = _stringConstant.ChannelAddSuccess;
-                //        }
-                //        else
-                //            returnMsg = _stringConstant.ProjectInActive;
-                //    }
-                //    else
-                //        returnMsg = _stringConstant.ProjectNotInOAuth;
-                //}
-                //else
-                //    // if user doesn't exist then this message will be shown to user
-                //    returnMsg = _stringConstant.YouAreNotInExistInOAuthServer;
-            }
-            else
-                return _stringConstant.OnlyPrivateChannel;
-
-            return returnMsg;
-        }
-
-
-        /// <summary>
-        /// Used to check whether channelId is of a private channel. - JJ
-        /// </summary>
-        /// <param name="slackChannelId">Id of the slack channel</param>
-        /// <returns>true if private channel</returns>
-        private bool IsPrivateChannel(string slackChannelId)
-        {
-            return (slackChannelId.StartsWith(_stringConstant.GroupNameStartsWith, StringComparison.Ordinal)) ? true : false;
-        }
-
-
-        /// <summary>
         /// This method is used to add/update Scrum answer to/in the database. - JJ
         /// </summary>
         /// <param name="scrumId">Id of scrum of the channel for that day</param>
@@ -742,12 +687,12 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <summary>
         /// This method will be called when the keyword "scrum time" is encountered. - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="projectId">slack channel id from which message is send</param>
         /// <param name="users">List of users of the project(in OAuth) corresponding to slack channel</param>
         /// <param name="project">project(in OAuth) corresponding to slack channel</param>
         ///<param name="scrumStatus">status of scrum</param>
         /// <returns>The next question or the scrum complete message</returns>
-        private async Task<string> StartScrumAsync(string slackChannelId, List<User> users, ProjectAc project, ScrumStatus scrumStatus)
+        private async Task<string> StartScrumAsync(int projectId, List<User> users, ProjectAc project, ScrumStatus scrumStatus)
         {
             string replyMessage = string.Empty;
             List<Question> questionList = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
@@ -774,7 +719,6 @@ namespace Promact.Core.Repository.ScrumRepository
                     }
                     Scrum scrum = new Scrum();
                     scrum.CreatedOn = DateTime.UtcNow.Date;
-                    scrum.SlackChannelId = slackChannelId;
                     scrum.ScrumDate = DateTime.UtcNow.Date;
                     scrum.ProjectId = project.Id;
                     scrum.TeamLeaderId = project.TeamLeaderId;
@@ -794,7 +738,7 @@ namespace Promact.Core.Repository.ScrumRepository
             }
             else if (scrumStatus == ScrumStatus.OnGoing)
             {
-                Scrum scrum = await GetScrumAsync(slackChannelId);
+                Scrum scrum = await GetScrumAsync(projectId);
                 SlackUserDetailAc prevUserAc = new SlackUserDetailAc();
                 if (scrum != null)
                     //user to whom the last question was asked
@@ -1244,9 +1188,8 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <param name="project">project(in OAuth) corresponding to slack channel</param>
         /// <param name="users">List of users of the project(in OAuth) corresponding to slack channel</param>
         /// <param name="questions">List of questions to be asked in scrum</param>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <returns>object of ScrumStatus</returns>
-        private async Task<ScrumStatus> FetchScrumStatusAsync(ProjectAc project, List<User> users, List<Question> questions, string slackChannelId)
+        private async Task<ScrumStatus> FetchScrumStatusAsync(ProjectAc project, List<User> users, List<Question> questions)
         {
             if (project?.Id > 0)
             {
@@ -1385,6 +1328,34 @@ namespace Promact.Core.Repository.ScrumRepository
                 default: return null;
             }
             return returnMessage;
+        }
+
+
+        /// <summary>
+        /// Get users of the OAuth project corresponding to the given slackChannelName - JJ
+        /// </summary>
+        /// <param name="projectId">slack channel name from which the message has been send</param>
+        /// <param name="accessToken">Access token of the interacting user</param>
+        /// <returns>list of object of User</returns>
+        private async Task<ProjectAc> GetOAuthProjectAsync(int projectId, string accessToken)
+        {
+            ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
+            //Users of the OAuth project corresponding to the given slackChannelName
+            List<User> users = project?.Users;
+            if (users?.Count > 0)
+            {
+                var ids = users.Select(a => a.Id);
+                //Application Users in Erp who are members of the OAuth project corresponding to the given slackChannelName 
+                var appUsers = _applicationUser.FetchAsync(x => ids.Contains(x.Id)).Result
+                    .Select(y => new { Id = y.Id, SlackUserId = y.SlackUserId }).ToList();
+                //assign SlackUserId 
+                users.ForEach(x =>
+                {
+                    x.SlackUserId = appUsers.FirstOrDefault(y => y.Id == x.Id)?.SlackUserId;
+                });
+                project.Users = users.Where(x => !string.IsNullOrEmpty(x.SlackUserId)).ToList();
+            }
+            return project;
         }
 
 

--- a/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
@@ -16,6 +16,7 @@ using Promact.Core.Repository.AttachmentRepository;
 using Promact.Core.Repository.BotQuestionRepository;
 using Promact.Core.Repository.BaseRepository;
 using NLog;
+using Promact.Core.Repository.ScrumSetUpRepository;
 
 namespace Promact.Core.Repository.ScrumRepository
 {
@@ -36,10 +37,10 @@ namespace Promact.Core.Repository.ScrumRepository
         private readonly ISlackUserRepository _slackUserDetailRepository;
         private readonly IStringConstantRepository _stringConstant;
         private readonly IBotQuestionRepository _botQuestionRepository;
+        private readonly IScrumSetUpRepository _scrumSetUpRepository;
         private readonly IMapper _mapper;
         private readonly DateTime _today;
         private readonly ILogger _logger;
-
 
         #endregion
 
@@ -53,7 +54,7 @@ namespace Promact.Core.Repository.ScrumRepository
             IRepository<SlackUserDetails> slackUserDetailsDataRepository,
             ISlackChannelRepository slackChannelRepository, IOauthCallsRepository oauthCallsRepository,
             ISlackUserRepository slackUserDetailRepository, IStringConstantRepository stringConstant,
-            IBotQuestionRepository botQuestionRepository, IMapper mapper,
+            IBotQuestionRepository botQuestionRepository, IMapper mapper, IScrumSetUpRepository scrumSetUpRepository,
             IRepository<ApplicationUser> applicationUser, IAttachmentRepository attachmentRepository)
             : base(applicationUser, attachmentRepository)
         {
@@ -69,6 +70,7 @@ namespace Promact.Core.Repository.ScrumRepository
             _stringConstant = stringConstant;
             _botQuestionRepository = botQuestionRepository;
             _applicationUser = applicationUser;
+            _scrumSetUpRepository = scrumSetUpRepository;
             _mapper = mapper;
             _today = DateTime.UtcNow.Date;
         }
@@ -108,34 +110,39 @@ namespace Promact.Core.Repository.ScrumRepository
 
                 if (accessToken != null)
                 {
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync((int)slackChannelDetail.ProjectId, accessToken);
-                    if (project?.Id > 0)
+                    if (slackChannelDetail != null && slackChannelDetail.ProjectId != null)
                     {
-                        Scrum scrum = _scrumDataRepository.FirstOrDefault(x => x.ProjectId == project.Id && x.ScrumDate == date);
-                        if (scrum != null)
+                        ProjectAc project = await GetOAuthProjectAsync((int)slackChannelDetail.ProjectId, accessToken);
+                        if (project?.Id > 0)
                         {
-                            _scrumDataRepository.Delete(scrum.Id);
-                            int scrumDelete = await _scrumDataRepository.SaveChangesAsync();
-                            if (scrumDelete == 1)
-                                replyText += "scrum has been deleted\n";
-                            else
-                                replyText += "scrum has not been deleted\n";
-                            TemporaryScrumDetails temp = _tempScrumDetailsDataRepository.FirstOrDefault(x => x.ScrumId == scrum.Id);
-                            if (temp != null)
+                            Scrum scrum = _scrumDataRepository.FirstOrDefault(x => x.ProjectId == project.Id && x.ScrumDate == date);
+                            if (scrum != null)
                             {
-                                _tempScrumDetailsDataRepository.Delete(temp.Id);
-                                int deleteTemp = await _tempScrumDetailsDataRepository.SaveChangesAsync();
-                                if (deleteTemp == 1)
-                                    replyText += "temp data has been deleted\n";
+                                _scrumDataRepository.Delete(scrum.Id);
+                                int scrumDelete = await _scrumDataRepository.SaveChangesAsync();
+                                if (scrumDelete == 1)
+                                    replyText += "scrum has been deleted\n";
                                 else
-                                    replyText += "temp data has not been deleted\n";
+                                    replyText += "scrum has not been deleted\n";
+                                TemporaryScrumDetails temp = _tempScrumDetailsDataRepository.FirstOrDefault(x => x.ScrumId == scrum.Id);
+                                if (temp != null)
+                                {
+                                    _tempScrumDetailsDataRepository.Delete(temp.Id);
+                                    int deleteTemp = await _tempScrumDetailsDataRepository.SaveChangesAsync();
+                                    if (deleteTemp == 1)
+                                        replyText += "temp data has been deleted\n";
+                                    else
+                                        replyText += "temp data has not been deleted\n";
+                                }
                             }
+                            else
+                                replyText += "no scrum cud be deleted\n";
                         }
                         else
-                            replyText += "no scrum cud be deleted\n";
+                            replyText = "Project not found in OAuth\n";
                     }
                     else
-                        replyText = "Project not found in OAuth\n";
+                        replyText = "Slack channel not linked to any Project in OAuth\n";
                 }
                 else
                     replyText = "Please login with OAuth\n";
@@ -153,58 +160,80 @@ namespace Promact.Core.Repository.ScrumRepository
                 }
                 else if (slackChannelDetail != null)
                 {
-                    //commands could be "scrum halt" or "scrum resume"
-                    if (String.Compare(message, _stringConstant.ScrumHalt, StringComparison.OrdinalIgnoreCase) == 0 ||
-                        String.Compare(message, _stringConstant.ScrumResume, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (String.Compare(messageArray[0], _stringConstant.Link, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        String.Compare(messageArray[0], _stringConstant.Unlink, StringComparison.OrdinalIgnoreCase) == 0 ||
+                        String.Compare(message, _stringConstant.ListLinks, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        _logger.Debug("Scrum command is :" + message);
-                        replyText = await ScrumAsync(slackChannelId, slackChannelDetail.Name, slackUserDetail.Name, messageArray[1].ToLower(), slackUserDetail.UserId);
+                        replyText = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(slackUserId, slackChannelDetail, message);
+                        if (string.IsNullOrEmpty(replyText))
+                            replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message, slackChannelDetail.ProjectId, slackUserId);
                     }
-                    //a particular user is on leave. command would be like "leave <@userId>"
-                    else if (((String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0) || (String.Compare(messageArray[0], _stringConstant.Start, StringComparison.OrdinalIgnoreCase) == 0)) && messageArray.Length == 2)
+                    else
                     {
-                        _logger.Debug("Scrum command is leave or start");
-                        //"<@".Length is 2
-                        int fromIndex = message.IndexOf("<@", StringComparison.Ordinal) + 2;
-                        int toIndex = message.LastIndexOf(">", StringComparison.Ordinal);
-                        if (toIndex > 0 && fromIndex > 1)
+                        #region code specific to scrum
+
+                        if (slackChannelDetail.ProjectId != null)
                         {
-                            //the slack userId is fetched
-                            string applicantId = message.Substring(fromIndex, toIndex - fromIndex);
-                            _logger.Debug("Scrum command is leave or start. User mentioned is :" + applicantId);
-                            if (String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0)
+                            //commands could be "scrum halt" or "scrum resume"
+                            if (String.Compare(message, _stringConstant.ScrumHalt, StringComparison.OrdinalIgnoreCase) == 0 ||
+                                String.Compare(message, _stringConstant.ScrumResume, StringComparison.OrdinalIgnoreCase) == 0)
                             {
-                                _logger.Debug("Scrum command is leave");
-                                //fetch the user of the given userId
-                                SlackUserDetailAc applicantDetailsAc = await _slackUserDetailRepository.GetByIdAsync(applicantId);
-                                replyText = applicantDetailsAc != null ? await LeaveAsync(slackChannelId, slackChannelDetail.Name, slackUserDetail.Name, slackUserDetail.UserId, applicantDetailsAc.Name, applicantId) : _stringConstant.NotAUser;
+                                _logger.Debug("Scrum command is :" + message);
+                                replyText = await ScrumAsync((int)slackChannelDetail.ProjectId, slackUserDetail.Name, messageArray[1].ToLower(), slackUserDetail.UserId);
                             }
-                            else
+                            //a particular user is on leave. command would be like "leave <@userId>"
+                            else if (((String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0) || (String.Compare(messageArray[0], _stringConstant.Start, StringComparison.OrdinalIgnoreCase) == 0)) && messageArray.Length == 2)
                             {
-                                if (String.Compare(applicantId, scrumBotId, StringComparison.Ordinal) == 0)
+                                _logger.Debug("Scrum command is leave or start");
+                                //"<@".Length is 2
+                                int fromIndex = message.IndexOf("<@", StringComparison.Ordinal) + 2;
+                                int toIndex = message.LastIndexOf(">", StringComparison.Ordinal);
+                                if (toIndex > 0 && fromIndex > 1)
                                 {
-                                    _logger.Debug("Scrum command is start");
-                                    replyText = await ScrumAsync(slackChannelId, slackChannelDetail.Name, slackUserDetail.Name, messageArray[0].ToLower(), slackUserDetail.UserId);
+                                    //the slack userId is fetched
+                                    string applicantId = message.Substring(fromIndex, toIndex - fromIndex);
+                                    _logger.Debug("Scrum command is leave or start. User mentioned is :" + applicantId);
+                                    if (String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0)
+                                    {
+                                        _logger.Debug("Scrum command is leave");
+                                        //fetch the user of the given userId
+                                        SlackUserDetailAc applicantDetailsAc = await _slackUserDetailRepository.GetByIdAsync(applicantId);
+                                        replyText = applicantDetailsAc != null ? await LeaveAsync((int)slackChannelDetail.ProjectId, slackUserDetail.Name, slackUserDetail.UserId, applicantDetailsAc.Name, applicantId) : _stringConstant.NotAUser;
+                                    }
+                                    else
+                                    {
+                                        if (String.Compare(applicantId, scrumBotId, StringComparison.Ordinal) == 0)
+                                        {
+                                            _logger.Debug("Scrum command is start");
+                                            replyText = await ScrumAsync((int)slackChannelDetail.ProjectId, slackUserDetail.Name, messageArray[0].ToLower(), slackUserDetail.UserId);
+                                        }
+                                        else
+                                        {
+                                            _logger.Debug("Invalid start command");
+                                            replyText = string.Format(_stringConstant.InValidStartCommand, scrumBotId);
+                                        }
+                                    }
                                 }
-                                else
+                                else //when command would be like "leave <@>"
                                 {
-                                    _logger.Debug("Invalid start command");
-                                    replyText = string.Format(_stringConstant.InValidStartCommand, scrumBotId);
+                                    _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
+                                    replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
+                                        message, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
                                 }
+                            }
+                            else  //all other texts
+                            {
+                                _logger.Debug("AddScrumAnswerAsync method");
+                                replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
+                                     (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
                             }
                         }
-                        else //when command would be like "leave <@>"
+                        else
                         {
-                            _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
-                            replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
-                                message, slackChannelId, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
+                            replyText = _stringConstant.ProjectChannelNotLinked;
                         }
-                    }
-                    else  //all other texts
-                    {
-                        _logger.Debug("AddScrumAnswerAsync method");
-                        replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
-                            slackChannelId, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
+
+                        #endregion
                     }
                 }
                 else   //channel is not registered in the database
@@ -214,7 +243,7 @@ namespace Promact.Core.Repository.ScrumRepository
                         String.Compare(messageArray[1], _stringConstant.Channel, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         _logger.Debug("AddChannelManuallyAsync method");
-                        replyText = await AddChannelManuallyAsync(messageArray[2], slackChannelId, slackUserDetail.UserId);
+                        replyText = await _scrumSetUpRepository.AddChannelManuallyAsync(messageArray[2], slackChannelId, slackUserDetail.UserId);
                     }
                     //If any of the commands which scrum bot recognizes is encountered
                     else if ((((String.Compare(messageArray[0], _stringConstant.Leave, StringComparison.OrdinalIgnoreCase) == 0) || (String.Compare(messageArray[0], _stringConstant.Start, StringComparison.OrdinalIgnoreCase) == 0)) &&
@@ -229,9 +258,15 @@ namespace Promact.Core.Repository.ScrumRepository
             }
             else
             {
-                Scrum scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => String.Compare(x.SlackChannelId, slackChannelId, StringComparison.OrdinalIgnoreCase) == 0 &&
-                        DbFunctions.TruncateTime(x.ScrumDate) == _today);
-                _logger.Info(scrum?.ScrumDate);
+                Scrum scrum;
+                if (slackChannelDetail?.ProjectId != null)
+                {
+                    scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => x.ProjectId == slackChannelDetail.ProjectId &&
+                            DbFunctions.TruncateTime(x.ScrumDate) == _today);
+                    _logger.Info(scrum?.ScrumDate);
+                }
+                else
+                    scrum = null;
                 if (await IsScrumStartLeaveCommandAsync(scrumBotId, message, messageArray)
                    || String.Compare(message, _stringConstant.ScrumHalt, StringComparison.OrdinalIgnoreCase) == 0
                    || String.Compare(message, _stringConstant.ScrumResume, StringComparison.OrdinalIgnoreCase) == 0
@@ -244,7 +279,7 @@ namespace Promact.Core.Repository.ScrumRepository
             return replyText;
         }
 
-
+                
         #region Temporary Scrum Details
 
 
@@ -427,11 +462,11 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <summary>
         /// Fetch today's scrum - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="projectId">slack channel id from which message is send</param>
         /// <returns>Object of Scrum</returns>
-        private async Task<Scrum> GetScrumAsync(string slackChannelId)
+        private async Task<Scrum> GetScrumAsync(int projectId)
         {
-            var scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => String.Compare(x.SlackChannelId, slackChannelId, StringComparison.OrdinalIgnoreCase) == 0 &&
+            var scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => x.ProjectId == projectId &&
                         DbFunctions.TruncateTime(x.ScrumDate) == _today);
             _logger.Info(scrum?.ScrumDate);
             return scrum;
@@ -443,100 +478,79 @@ namespace Promact.Core.Repository.ScrumRepository
         /// </summary>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="message">the message that interacting user sends</param>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <returns>the next question statement</returns>
-        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, string slackChannelId, int projectId, string slackUserId)
+        private async Task<string> AddScrumAnswerAsync(string slackUserName, string message, int? projectId, string slackUserId)
         {
-            string reply = string.Empty;
-            //today's scrum of the channel 
-            Scrum scrum = await GetScrumAsync(slackChannelId);
-            if (scrum != null && scrum.IsOngoing && !scrum.IsHalted)
+            if (projectId != null)
             {
-                // get access token of user for promact oauth server
-                var accessToken = await GetAccessToken(slackUserId);
-                if (accessToken != null)
+                string reply = string.Empty;
+                //today's scrum of the channel 
+                Scrum scrum = await GetScrumAsync((int)projectId);
+                if (scrum != null && scrum.IsOngoing && !scrum.IsHalted)
                 {
-                    //list of scrum questions. Type = BotQuestionType.Scrum
-                    List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
-                    //users of the given channel name fetched from the oauth server
-                    List<User> users = await GetOAuthUsersAsync(projectId, accessToken);
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
-                    ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
-                    //scrumStatus could be anything like the project is in-active
-                    if (scrumStatus == ScrumStatus.OnGoing)
+                    // get access token of user for promact oauth server
+                    var accessToken = await GetAccessToken(slackUserId);
+                    if (accessToken != null)
                     {
-                        //status would be empty if the interacting user is same as the expected user.
-                        string status = await ExpectedUserAsync(scrum.Id, questions, users, slackUserName, slackUserId, scrum.ProjectId);
-                        if (string.IsNullOrEmpty(status))
+                        //list of scrum questions. Type = BotQuestionType.Scrum
+                        List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
+                        ProjectAc project = await GetOAuthProjectAsync((int)projectId, accessToken);
+                        //users of the given channel name fetched from the oauth server
+                        List<User> users = project?.Users;
+                        ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions);
+                        //scrumStatus could be anything like the project is in-active
+                        if (scrumStatus == ScrumStatus.OnGoing)
                         {
-                            TemporaryScrumDetails temporaryScrumDetails = await FetchTemporaryScrumDetailsAsync(scrum.Id);
-                            User user = users.First(x => x.SlackUserId == temporaryScrumDetails.SlackUserId);
-                            if (temporaryScrumDetails.QuestionId != null)
+                            //status would be empty if the interacting user is same as the expected user.
+                            string status = await ExpectedUserAsync(scrum.Id, questions, users, slackUserName, slackUserId, scrum.ProjectId);
+                            if (string.IsNullOrEmpty(status))
                             {
-                                AddAnswer(scrum.Id, (int)temporaryScrumDetails.QuestionId, user.Id, message, ScrumAnswerStatus.Answered);
-                                await _scrumAnswerDataRepository.SaveChangesAsync();
-                            }
-                            else
-                                return _stringConstant.AnswerNotRecorded;
+                                TemporaryScrumDetails temporaryScrumDetails = await FetchTemporaryScrumDetailsAsync(scrum.Id);
+                                User user = users.First(x => x.SlackUserId == temporaryScrumDetails.SlackUserId);
+                                if (temporaryScrumDetails.QuestionId != null)
+                                {
+                                    AddAnswer(scrum.Id, (int)temporaryScrumDetails.QuestionId, user.Id, message, ScrumAnswerStatus.Answered);
+                                    await _scrumAnswerDataRepository.SaveChangesAsync();
+                                }
+                                else
+                                    return _stringConstant.AnswerNotRecorded;
 
-                            //update the details in temporary table 
-                            await UpdateTemporaryScrumDetailsAsync(slackUserId, scrum.Id, users, null);
-                            //get the next question
-                            reply = await GetQuestionAsync(scrum.Id, questions, users, scrum.ProjectId);
+                                //update the details in temporary table 
+                                await UpdateTemporaryScrumDetailsAsync(slackUserId, scrum.Id, users, null);
+                                //get the next question
+                                reply = await GetQuestionAsync(scrum.Id, questions, users, scrum.ProjectId);
+                            }
+                            //the user interacting is not the expected user
+                            else
+                                reply = status;
                         }
-                        //the user interacting is not the expected user
                         else
-                            reply = status;
+                            reply = ReplyStatusofScrumToClient(scrumStatus);
                     }
                     else
-                        reply = ReplyStatusofScrumToClient(scrumStatus);
+                        // if user doesn't exist then this message will be shown to user
+                        reply = _stringConstant.YouAreNotInExistInOAuthServer;
                 }
-                else
-                    // if user doesn't exist then this message will be shown to user
-                    reply = _stringConstant.YouAreNotInExistInOAuthServer;
+                return reply;
             }
-            return reply;
-        }
-
-
-        /// <summary>
-        /// Get users of the OAuth project corresponding to the given slackChannelName - JJ
-        /// </summary>
-        /// <param name="slackChannelName">slack channel name from which the message has been send</param>
-        /// <param name="accessToken">Access token of the interacting user</param>
-        /// <returns>list of object of User</returns>
-        private async Task<List<User>> GetOAuthUsersAsync(string slackChannelName, string accessToken)
-        {
-            //Users of the OAuth project corresponding to the given slackChannelName
-            List<User> users = await _oauthCallsRepository.GetUsersByChannelNameAsync(slackChannelName, accessToken);
-            var ids = users.Select(a => a.Id);
-            //Application Users in Erp who are members of the OAuth project corresponding to the given slackChannelName 
-            var appUsers = _applicationUser.FetchAsync(x => ids.Contains(x.Id)).Result
-                .Select(y => new { Id = y.Id, SlackUserId = y.SlackUserId }).ToList();
-            //assign SlackUserId 
-            users.ForEach(x =>
-            {
-                x.SlackUserId = appUsers.FirstOrDefault(y => y.Id == x.Id)?.SlackUserId;
-            });
-            return users.Where(x => !string.IsNullOrEmpty(x.SlackUserId)).ToList();
+            return _stringConstant.ProjectChannelNotLinked;
         }
 
 
         /// <summary>
         /// This method will be called when the keyword "scrum time" or "scrum halt" or "scrum resume" is encountered. - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="parameter">the keyword(second word) send by the user</param>      
         /// <param name="slackUserId">slack userId of the interacting user</param>
         /// <returns>The question or the status of the scrum</returns>
-        private async Task<string> ScrumAsync(string slackChannelId, int projectId, string slackUserName, string parameter, string slackUserId)
+        private async Task<string> ScrumAsync(int projectId, string slackUserName, string parameter, string slackUserId)
         {
             //because any command outside the scrum time must not be entertained except with the replies like "scrum is concluded","scrum has not started" or "scrum has not started".
-            Scrum scrum = await GetScrumAsync(slackChannelId);
+            Scrum scrum = await GetScrumAsync(projectId);
             ScrumActions scrumCommand = (ScrumActions)Enum.Parse(typeof(ScrumActions), parameter);
             if (scrumCommand == ScrumActions.start || scrum != null)
             {
@@ -546,53 +560,57 @@ namespace Promact.Core.Repository.ScrumRepository
                     var accessToken = await GetAccessToken(slackUserId);
                     if (accessToken != null)
                     {
-                        List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                        ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
-                        ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, null, slackChannelId);
-
-                        if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
+                        ProjectAc project = await GetOAuthProjectAsync(projectId, accessToken);
+                        List<User> users = project?.Users;
+                        ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, null);
+                        if (users?.Count > 0)
                         {
-                            switch (scrumCommand)
+                            if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
                             {
-                                case ScrumActions.halt:
-                                    //keyword encountered is "scrum halt"
-                                    return await ScrumHaltAsync(scrum, scrumStatus);
-                                case ScrumActions.resume:
-                                    //keyword encountered is "scrum resume"
-                                    return await ScrumResumeAsync(scrum, users, scrumStatus);
-                                case ScrumActions.start:
-                                    //keyword encountered is "start <@botId>"
-                                    return await StartScrumAsync(slackChannelId, users, project, scrumStatus);
-                                default:
-                                    return string.Empty;
+                                switch (scrumCommand)
+                                {
+                                    case ScrumActions.halt:
+                                        //keyword encountered is "scrum halt"
+                                        return await ScrumHaltAsync(scrum, scrumStatus);
+                                    case ScrumActions.resume:
+                                        //keyword encountered is "scrum resume"
+                                        return await ScrumResumeAsync(scrum, users, scrumStatus);
+                                    case ScrumActions.start:
+                                        //keyword encountered is "start <@botId>"
+                                        return await StartScrumAsync(projectId, users, project, scrumStatus);
+                                    default:
+                                        return string.Empty;
+                                }
                             }
-                        }
-                        //if user is in-active
-                        string returnMessage;
-                        switch (scrumStatus)
-                        {
-                            case ScrumStatus.Halted:
-                                returnMessage = (scrumCommand == ScrumActions.resume ? _stringConstant.ScrumCannotBeResumed : string.Empty) + string.Format(_stringConstant.InActiveInOAuth, slackUserName);
-                                break;
-                            //scrum is in progress
-                            case ScrumStatus.OnGoing:
-                                List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
-                                if (scrum != null)
-                                    returnMessage = await GetReplyToUserAsync(users, project.Id, scrum.Id, slackUserId, slackUserName, questions);
-                                else
-                                    return _stringConstant.ErrorMsgNewPrivateChannel;
-                                if (scrumCommand == ScrumActions.resume)
-                                    returnMessage = _stringConstant.ScrumNotHalted + Environment.NewLine + returnMessage;
-                                else if (scrumCommand == ScrumActions.halt)
-                                    returnMessage = _stringConstant.ScrumCannotBeHalted + Environment.NewLine + returnMessage;
-                                break;
+                            //if user is in-active
+                            string returnMessage;
+                            switch (scrumStatus)
+                            {
+                                case ScrumStatus.Halted:
+                                    returnMessage = (scrumCommand == ScrumActions.resume ? _stringConstant.ScrumCannotBeResumed : string.Empty) + string.Format(_stringConstant.InActiveInOAuth, slackUserName);
+                                    break;
+                                //scrum is in progress
+                                case ScrumStatus.OnGoing:
+                                    List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
+                                    if (scrum != null)
+                                        returnMessage = await GetReplyToUserAsync(users, project.Id, scrum.Id, slackUserId, slackUserName, questions);
+                                    else
+                                        return _stringConstant.ErrorMsgNewPrivateChannel;
+                                    if (scrumCommand == ScrumActions.resume)
+                                        returnMessage = _stringConstant.ScrumNotHalted + Environment.NewLine + returnMessage;
+                                    else if (scrumCommand == ScrumActions.halt)
+                                        returnMessage = _stringConstant.ScrumCannotBeHalted + Environment.NewLine + returnMessage;
+                                    break;
 
-                            //for all other status of the scrum
-                            default:
-                                returnMessage = ReplyStatusofScrumToClient(scrumStatus);
-                                break;
+                                //for all other status of the scrum
+                                default:
+                                    returnMessage = ReplyStatusofScrumToClient(scrumStatus);
+                                    break;
+                            }
+                            return returnMessage;
                         }
-                        return returnMessage;
+                        else
+                            return _stringConstant.NoEmployeeFound;
                     }
                     return _stringConstant.YouAreNotInExistInOAuthServer;
                 }
@@ -605,19 +623,18 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <summary>
         /// This method will be called when the keyword "leave @username" is received as reply from a channel member. - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <param name="applicant">slack user name of the user who is being marked on leave</param>
         /// <param name="applicantId">slack user id of the user who is being marked on leave</param>
         /// <returns>Question to the next person or other scrum status</returns>
-        private async Task<string> LeaveAsync(string slackChannelId, int projectId, string slackUserName, string slackUserId, string applicant, string applicantId)
+        private async Task<string> LeaveAsync(int projectId, string slackUserName, string slackUserId, string applicant, string applicantId)
         {
             string returnMsg;
             //we will have to check whether the scrum is on going or not before calling FetchScrumStatus()
             //because any command outside the scrum time must not be entertained except with the replies like "scrum is concluded","scrum has not started" or "scrum has not started".
-            Scrum scrum = await GetScrumAsync(slackChannelId);
+            Scrum scrum = await GetScrumAsync(projectId);
             if (scrum != null)
             {
                 if (scrum.IsOngoing)
@@ -629,10 +646,9 @@ namespace Promact.Core.Repository.ScrumRepository
                         if (accessToken != null)
                         {
                             List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
-                            List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                            ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
-
-                            ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
+                            ProjectAc project = await GetOAuthProjectAsync(projectId, accessToken);
+                            List<User> users = project?.Users;
+                            ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions);
                             if (scrumStatus == ScrumStatus.OnGoing)
                             {
                                 if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
@@ -661,66 +677,6 @@ namespace Promact.Core.Repository.ScrumRepository
 
 
         /// <summary>
-        /// Used to add channel manually by command "add channel channelname". - JJ
-        /// </summary>
-        /// <param name="slackChannelName">slack channel name from which message is send</param>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
-        /// <param name="slackUserId">slack user id of interacting user</param>
-        /// <returns>status message</returns>
-        private async Task<string> AddChannelManuallyAsync(string slackChannelName, string slackChannelId, string slackUserId)
-        {
-            string returnMsg;
-            //Checks whether channelId starts with "G". This is done inorder to make sure that only private channels are added manually
-            if (IsPrivateChannel(slackChannelId))
-            {
-                //// get access token of user for promact oauth server
-                //var accessToken = await GetAccessToken(slackUserId);
-                //if (accessToken != null)
-                //{
-                //    //get the project details of the given channel name
-                //    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
-                //    //add channel details only if the channel has been registered as project in OAuth server
-                //    if (project?.Id > 0)
-                //    {
-                //        if (project.IsActive)
-                //        {
-                SlackChannelDetails slackChannelDetails = new SlackChannelDetails();
-                slackChannelDetails.ChannelId = slackChannelId;
-                slackChannelDetails.CreatedOn = DateTime.UtcNow;
-                slackChannelDetails.Deleted = false;
-                slackChannelDetails.Name = slackChannelName;
-                await _slackChannelRepository.AddSlackChannelAsync(slackChannelDetails);
-                returnMsg = _stringConstant.ChannelAddSuccess;
-                //        }
-                //        else
-                //            returnMsg = _stringConstant.ProjectInActive;
-                //    }
-                //    else
-                //        returnMsg = _stringConstant.ProjectNotInOAuth;
-                //}
-                //else
-                //    // if user doesn't exist then this message will be shown to user
-                //    returnMsg = _stringConstant.YouAreNotInExistInOAuthServer;
-            }
-            else
-                return _stringConstant.OnlyPrivateChannel;
-
-            return returnMsg;
-        }
-
-
-        /// <summary>
-        /// Used to check whether channelId is of a private channel. - JJ
-        /// </summary>
-        /// <param name="slackChannelId">Id of the slack channel</param>
-        /// <returns>true if private channel</returns>
-        private bool IsPrivateChannel(string slackChannelId)
-        {
-            return (slackChannelId.StartsWith(_stringConstant.GroupNameStartsWith, StringComparison.Ordinal)) ? true : false;
-        }
-
-
-        /// <summary>
         /// This method is used to add/update Scrum answer to/in the database. - JJ
         /// </summary>
         /// <param name="scrumId">Id of scrum of the channel for that day</param>
@@ -745,12 +701,12 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <summary>
         /// This method will be called when the keyword "scrum time" is encountered. - JJ
         /// </summary>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="projectId">slack channel id from which message is send</param>
         /// <param name="users">List of users of the project(in OAuth) corresponding to slack channel</param>
         /// <param name="project">project(in OAuth) corresponding to slack channel</param>
         ///<param name="scrumStatus">status of scrum</param>
         /// <returns>The next question or the scrum complete message</returns>
-        private async Task<string> StartScrumAsync(string slackChannelId, List<User> users, ProjectAc project, ScrumStatus scrumStatus)
+        private async Task<string> StartScrumAsync(int projectId, List<User> users, ProjectAc project, ScrumStatus scrumStatus)
         {
             string replyMessage = string.Empty;
             List<Question> questionList = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
@@ -777,7 +733,6 @@ namespace Promact.Core.Repository.ScrumRepository
                     }
                     Scrum scrum = new Scrum();
                     scrum.CreatedOn = DateTime.UtcNow.Date;
-                    scrum.SlackChannelId = slackChannelId;
                     scrum.ScrumDate = DateTime.UtcNow.Date;
                     scrum.ProjectId = project.Id;
                     scrum.TeamLeaderId = project.TeamLeaderId;
@@ -797,7 +752,7 @@ namespace Promact.Core.Repository.ScrumRepository
             }
             else if (scrumStatus == ScrumStatus.OnGoing)
             {
-                Scrum scrum = await GetScrumAsync(slackChannelId);
+                Scrum scrum = await GetScrumAsync(projectId);
                 SlackUserDetailAc prevUserAc = new SlackUserDetailAc();
                 if (scrum != null)
                     //user to whom the last question was asked
@@ -1246,9 +1201,8 @@ namespace Promact.Core.Repository.ScrumRepository
         /// <param name="project">project(in OAuth) corresponding to slack channel</param>
         /// <param name="users">List of users of the project(in OAuth) corresponding to slack channel</param>
         /// <param name="questions">List of questions to be asked in scrum</param>
-        /// <param name="slackChannelId">slack channel id from which message is send</param>
         /// <returns>object of ScrumStatus</returns>
-        private async Task<ScrumStatus> FetchScrumStatusAsync(ProjectAc project, List<User> users, List<Question> questions, string slackChannelId)
+        private async Task<ScrumStatus> FetchScrumStatusAsync(ProjectAc project, List<User> users, List<Question> questions)
         {
             if (project?.Id > 0)
             {
@@ -1260,7 +1214,7 @@ namespace Promact.Core.Repository.ScrumRepository
                             questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
                         if (questions.Any())
                         {
-                            Scrum scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => String.Compare(x.SlackChannelId, slackChannelId, StringComparison.OrdinalIgnoreCase) == 0 && x.ProjectId == project.Id
+                            Scrum scrum = await _scrumDataRepository.FirstOrDefaultAsync(x => x.ProjectId == project.Id
                             && DbFunctions.TruncateTime(x.ScrumDate) == _today);
                             if (scrum != null)
                             {
@@ -1386,6 +1340,34 @@ namespace Promact.Core.Repository.ScrumRepository
                 default: return null;
             }
             return returnMessage;
+        }
+
+
+        /// <summary>
+        /// Get users of the OAuth project corresponding to the given slackChannelName - JJ
+        /// </summary>
+        /// <param name="projectId">slack channel name from which the message has been send</param>
+        /// <param name="accessToken">Access token of the interacting user</param>
+        /// <returns>list of object of User</returns>
+        private async Task<ProjectAc> GetOAuthProjectAsync(int projectId, string accessToken)
+        {
+            ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
+            //Users of the OAuth project corresponding to the given slackChannelName
+            List<User> users = project?.Users;
+            if (users?.Count > 0)
+            {
+                var ids = users.Select(a => a.Id);
+                //Application Users in Erp who are members of the OAuth project corresponding to the given slackChannelName 
+                var appUsers = _applicationUser.FetchAsync(x => ids.Contains(x.Id)).Result
+                    .Select(y => new { Id = y.Id, SlackUserId = y.SlackUserId }).ToList();
+                //assign SlackUserId 
+                users.ForEach(x =>
+                {
+                    x.SlackUserId = appUsers.FirstOrDefault(y => y.Id == x.Id)?.SlackUserId;
+                });
+                project.Users = users.Where(x => !string.IsNullOrEmpty(x.SlackUserId)).ToList();
+            }
+            return project;
         }
 
 

--- a/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumRepository/ScrumBotRepository.cs
@@ -197,14 +197,14 @@ namespace Promact.Core.Repository.ScrumRepository
                         {
                             _logger.Debug("Invalid leave command. So call AddScrumAnswerAsync method");
                             replyText = await AddScrumAnswerAsync(slackUserDetail.Name,
-                                message, slackChannelId, slackChannelDetail.ProjectId, slackUserDetail.UserId);
+                                message, slackChannelId, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
                         }
                     }
                     else  //all other texts
                     {
                         _logger.Debug("AddScrumAnswerAsync method");
                         replyText = await AddScrumAnswerAsync(slackUserDetail.Name, message,
-                            slackChannelId, slackChannelDetail.ProjectId, slackUserDetail.UserId);
+                            slackChannelId, (int)slackChannelDetail.ProjectId, slackUserDetail.UserId);
                     }
                 }
                 else   //channel is not registered in the database
@@ -528,12 +528,12 @@ namespace Promact.Core.Repository.ScrumRepository
         /// This method will be called when the keyword "scrum time" or "scrum halt" or "scrum resume" is encountered. - JJ
         /// </summary>
         /// <param name="slackChannelId">slack channel id from which message is send</param>
-        /// <param name="slackChannelName">slack channel name from which the message has been send</param>
+        /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="parameter">the keyword(second word) send by the user</param>      
         /// <param name="slackUserId">slack userId of the interacting user</param>
         /// <returns>The question or the status of the scrum</returns>
-        private async Task<string> ScrumAsync(string slackChannelId, string slackChannelName, string slackUserName, string parameter, string slackUserId)
+        private async Task<string> ScrumAsync(string slackChannelId, int projectId, string slackUserName, string parameter, string slackUserId)
         {
             //because any command outside the scrum time must not be entertained except with the replies like "scrum is concluded","scrum has not started" or "scrum has not started".
             Scrum scrum = await GetScrumAsync(slackChannelId);
@@ -547,7 +547,7 @@ namespace Promact.Core.Repository.ScrumRepository
                     if (accessToken != null)
                     {
                         List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                        ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
+                        ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
                         ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, null, slackChannelId);
 
                         if (await CheckUserAsync(slackUserId, users, project.TeamLeaderId))
@@ -606,13 +606,13 @@ namespace Promact.Core.Repository.ScrumRepository
         /// This method will be called when the keyword "leave @username" is received as reply from a channel member. - JJ
         /// </summary>
         /// <param name="slackChannelId">slack channel id from which message is send</param>
-        /// <param name="slackChannelName">slack channel name from which the message has been send</param>
+        /// <param name="projectId">slack channel name from which the message has been send</param>
         /// <param name="slackUserName">slack user name of the interacting user</param>
         /// <param name="slackUserId">slack user Id of the interacting user</param>
         /// <param name="applicant">slack user name of the user who is being marked on leave</param>
         /// <param name="applicantId">slack user id of the user who is being marked on leave</param>
         /// <returns>Question to the next person or other scrum status</returns>
-        private async Task<string> LeaveAsync(string slackChannelId, string slackChannelName, string slackUserName, string slackUserId, string applicant, string applicantId)
+        private async Task<string> LeaveAsync(string slackChannelId, int projectId, string slackUserName, string slackUserId, string applicant, string applicantId)
         {
             string returnMsg;
             //we will have to check whether the scrum is on going or not before calling FetchScrumStatus()
@@ -630,7 +630,7 @@ namespace Promact.Core.Repository.ScrumRepository
                         {
                             List<Question> questions = await _botQuestionRepository.GetQuestionsByTypeAsync(BotQuestionType.Scrum);
                             List<User> users = await GetOAuthUsersAsync(slackChannelName, accessToken);
-                            ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
+                            ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(projectId, accessToken);
 
                             ScrumStatus scrumStatus = await FetchScrumStatusAsync(project, users, questions, slackChannelId);
                             if (scrumStatus == ScrumStatus.OnGoing)
@@ -673,34 +673,34 @@ namespace Promact.Core.Repository.ScrumRepository
             //Checks whether channelId starts with "G". This is done inorder to make sure that only private channels are added manually
             if (IsPrivateChannel(slackChannelId))
             {
-                // get access token of user for promact oauth server
-                var accessToken = await GetAccessToken(slackUserId);
-                if (accessToken != null)
-                {
-                    //get the project details of the given channel name
-                    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
-                    //add channel details only if the channel has been registered as project in OAuth server
-                    if (project?.Id > 0)
-                    {
-                        if (project.IsActive)
-                        {
-                            SlackChannelDetails slackChannelDetails = new SlackChannelDetails();
-                            slackChannelDetails.ChannelId = slackChannelId;
-                            slackChannelDetails.CreatedOn = DateTime.UtcNow;
-                            slackChannelDetails.Deleted = false;
-                            slackChannelDetails.Name = slackChannelName;
-                            await _slackChannelRepository.AddSlackChannelAsync(slackChannelDetails);
-                            returnMsg = _stringConstant.ChannelAddSuccess;
-                        }
-                        else
-                            returnMsg = _stringConstant.ProjectInActive;
-                    }
-                    else
-                        returnMsg = _stringConstant.ProjectNotInOAuth;
-                }
-                else
-                    // if user doesn't exist then this message will be shown to user
-                    returnMsg = _stringConstant.YouAreNotInExistInOAuthServer;
+                //// get access token of user for promact oauth server
+                //var accessToken = await GetAccessToken(slackUserId);
+                //if (accessToken != null)
+                //{
+                //    //get the project details of the given channel name
+                //    ProjectAc project = await _oauthCallsRepository.GetProjectDetailsAsync(slackChannelName, accessToken);
+                //    //add channel details only if the channel has been registered as project in OAuth server
+                //    if (project?.Id > 0)
+                //    {
+                //        if (project.IsActive)
+                //        {
+                SlackChannelDetails slackChannelDetails = new SlackChannelDetails();
+                slackChannelDetails.ChannelId = slackChannelId;
+                slackChannelDetails.CreatedOn = DateTime.UtcNow;
+                slackChannelDetails.Deleted = false;
+                slackChannelDetails.Name = slackChannelName;
+                await _slackChannelRepository.AddSlackChannelAsync(slackChannelDetails);
+                returnMsg = _stringConstant.ChannelAddSuccess;
+                //        }
+                //        else
+                //            returnMsg = _stringConstant.ProjectInActive;
+                //    }
+                //    else
+                //        returnMsg = _stringConstant.ProjectNotInOAuth;
+                //}
+                //else
+                //    // if user doesn't exist then this message will be shown to user
+                //    returnMsg = _stringConstant.YouAreNotInExistInOAuthServer;
             }
             else
                 return _stringConstant.OnlyPrivateChannel;

--- a/Slack.Automation/Promact.Core.Repository/ScrumSetUpRepository/IScrumSetUpRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumSetUpRepository/IScrumSetUpRepository.cs
@@ -1,0 +1,28 @@
+﻿using Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse;
+using System.Threading.Tasks;
+
+namespace Promact.Core.Repository.ScrumSetUpRepository
+{
+    public interface IScrumSetUpRepository
+    {
+        /// <summary>
+        /// It is called when the message is "list links","link "project"" or "unlink "project"" - JJ
+        /// </summary>
+        /// <param name="slackUserId">UserId of slack user</param>
+        /// <param name="slackChannel">slack channel from which message is send</param>
+        /// <param name="message">message from slack</param>
+        /// <returns>appropriate message</returns>
+        Task<string> ProcessSetUpMessagesAsync(string slackUserId, SlackChannelDetails slackChannel, string message);
+
+
+        /// <summary>
+        /// Used to add channel manually by command "add channel channelname". - JJ
+        /// </summary>
+        /// <param name="slackChannelName">slack channel name from which message is send</param>
+        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="slackUserId">slack user id of interacting user</param>
+        /// <returns>status message</returns>
+        Task<string> AddChannelManuallyAsync(string slackChannelName, string slackChannelId, string slackUserId);
+
+    }
+}

--- a/Slack.Automation/Promact.Core.Repository/ScrumSetUpRepository/ScrumSetUpRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumSetUpRepository/ScrumSetUpRepository.cs
@@ -1,0 +1,330 @@
+﻿using Promact.Core.Repository.AttachmentRepository;
+using Promact.Core.Repository.BaseRepository;
+using Promact.Core.Repository.OauthCallsRepository;
+using Promact.Core.Repository.SlackChannelRepository;
+using Promact.Erp.DomainModel.ApplicationClass;
+using Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse;
+using Promact.Erp.DomainModel.DataRepository;
+using Promact.Erp.DomainModel.Models;
+using Promact.Erp.Util.StringConstants;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Promact.Core.Repository.ScrumSetUpRepository
+{
+    public class ScrumSetUpRepository : RepositoryBase, IScrumSetUpRepository
+    {
+
+        #region Private Variable 
+
+
+        private readonly IRepository<SlackChannelDetails> _slackChannelDetailsReposirtory;
+        private readonly IRepository<ApplicationUser> _applicationUser;
+        private readonly ISlackChannelRepository _slackChannelRepository;
+        private readonly IOauthCallsRepository _oauthCallsRepository;
+        private readonly IStringConstantRepository _stringConstant;
+
+
+        #endregion
+
+
+        #region Constructor
+
+
+        public ScrumSetUpRepository(
+            IRepository<SlackChannelDetails> slackChannelDetailsReposirtory,
+            ISlackChannelRepository slackChannelRepository,
+            IOauthCallsRepository oauthCallsRepository,
+            IStringConstantRepository stringConstant,
+            IRepository<ApplicationUser> applicationUser,
+            IAttachmentRepository attachmentRepository)
+            : base(applicationUser, attachmentRepository)
+        {
+            _slackChannelDetailsReposirtory = slackChannelDetailsReposirtory;
+            _slackChannelRepository = slackChannelRepository;
+            _oauthCallsRepository = oauthCallsRepository;
+            _stringConstant = stringConstant;
+            _applicationUser = applicationUser;
+        }
+
+
+        #endregion
+
+
+        #region Public Method
+
+
+        /// <summary>
+        /// It is called when the message is "list links","link "project"" or "unlink "project"" - JJ
+        /// </summary>
+        /// <param name="slackUserId">UserId of slack user</param>
+        /// <param name="slackChannel">slack channel from which message is send</param>
+        /// <param name="message">message from slack</param>
+        /// <returns>appropriate message</returns>
+        public async Task<string> ProcessSetUpMessagesAsync(string slackUserId, SlackChannelDetails slackChannel, string message)
+        {
+            if (String.Compare(message, _stringConstant.ListLinks, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return await ListLinkAsync(slackUserId);
+            }
+            else
+            {
+                string[] messageArray = message.Split(null);
+                int messageLength = message.Length - 1;
+                int first = message.IndexOf('"') + 1; //first index of ".
+                int last = message.IndexOf('"', message.IndexOf('"') + 1);//last index of "
+                int projectNameStartIndex = messageArray[0].Length + 2;// index from where the name of the project starts
+
+                if (messageLength == last && first == projectNameStartIndex)
+                {
+                    //fetch the project name from the message string
+                    string name = message.Substring(first, last - first);
+                    if (string.IsNullOrEmpty(name))// ex. link ""
+                        return null;// it will be considered as a normal message
+                    return await ProcessCommandsAsync(slackUserId, slackChannel.ChannelId, name, messageArray[0]);
+                }
+                else
+                {
+                    if (slackChannel.ProjectId != null)
+                        return null;
+                    return _stringConstant.ProjectChannelNotLinked;
+                }
+            }
+        }
+
+
+        /// <summary>
+        /// Used to add channel manually by command "add channel channelname". - JJ
+        /// </summary>
+        /// <param name="slackChannelName">slack channel name from which message is send</param>
+        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="slackUserId">slack user id of interacting user</param>
+        /// <returns>status message</returns>
+        public async Task<string> AddChannelManuallyAsync(string slackChannelName, string slackChannelId, string slackUserId)
+        {
+            string returnMsg;
+            //Checks whether channelId starts with "G" or "C". This is done inorder to make sure that only gruops or channels are added manually
+            if (IsPrivateChannel(slackChannelId))
+            {
+                var accessToken = await GetAccessToken(slackUserId);
+                if (accessToken != null)
+                {
+                    SlackChannelDetails slackChannelDetails = new SlackChannelDetails();
+                    slackChannelDetails.ChannelId = slackChannelId;
+                    slackChannelDetails.CreatedOn = DateTime.UtcNow;
+                    slackChannelDetails.Deleted = false;
+                    slackChannelDetails.Name = slackChannelName;
+                    await _slackChannelRepository.AddSlackChannelAsync(slackChannelDetails);
+                    returnMsg = _stringConstant.ChannelAddSuccess;
+                }
+                else
+                    // if user doesn't exist then this message will be shown to user
+                    returnMsg = _stringConstant.YouAreNotInExistInOAuthServer;
+            }
+            else
+                returnMsg = _stringConstant.OnlyPrivateChannel;
+
+            return returnMsg;
+        }
+
+
+        #endregion
+
+
+        #region Private Method
+
+
+        /// <summary>
+        /// Used to check whether channelId is of a private channel. - JJ
+        /// </summary>
+        /// <param name="slackChannelId">Id of the slack channel</param>
+        /// <returns>true if private channel</returns>
+        private bool IsPrivateChannel(string slackChannelId)
+        {
+            return (slackChannelId.StartsWith(_stringConstant.GroupNameStartsWith, StringComparison.Ordinal) || slackChannelId.StartsWith("C", StringComparison.Ordinal)) ? true : false;
+        }
+
+
+        /// <summary>
+        /// Check various conditions before linking or unlinking slack channels to OAuth projects- JJ
+        /// </summary>
+        /// <param name="slackUserId">UserId of slack user</param>
+        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="givenProjectName">the project name mentioned in the slack message</param>
+        /// <param name="command">link or unlink</param>
+        /// <returns>appropriate message</returns>
+        private async Task<string> ProcessCommandsAsync(string slackUserId, string slackChannelId, string givenProjectName, string command)
+        {
+            string reply = string.Empty;
+            //Checks whether channelId starts with "G" or "C". This is done inorder to make sure that only gruops or channels are added manually
+            if (IsPrivateChannel(slackChannelId))
+            {
+                var accessToken = await GetAccessToken(slackUserId);
+                if (accessToken != null)
+                {
+                    ApplicationUser appUser = await _applicationUser.FirstAsync(x => x.SlackUserId == slackUserId);
+                    //the list of projects in which the user is either team leader or member
+                    List<ProjectAc> projectList = await _oauthCallsRepository.GetListOfProjectsEnrollmentOfUserByUserIdAsync(appUser.Id, accessToken);
+                    //the project which is mentioned by user
+                    ProjectAc project = projectList.FirstOrDefault(x => String.Compare(givenProjectName, x.Name, StringComparison.OrdinalIgnoreCase) == 0);
+                    if (project != null)
+                    {
+                        //check whether user is the team leader of the project
+                        if (project.TeamLeader != null && project.TeamLeaderId == appUser.Id)
+                        {
+                            if (project.TeamLeader.IsActive)
+                            {
+                                //command to link
+                                if (String.Compare(command, _stringConstant.Link, StringComparison.OrdinalIgnoreCase) == 0)
+                                {
+                                    reply = await LinkAsync(slackChannelId, givenProjectName, project);
+                                }
+                                //command to unlink
+                                else if (String.Compare(command, _stringConstant.Unlink, StringComparison.OrdinalIgnoreCase) == 0)
+                                {
+                                    reply = await UnlinkAsync(slackChannelId, givenProjectName, project);
+                                }
+                            }
+                            else
+                            {
+                                reply = string.Format(_stringConstant.NotActiveUser, slackUserId);
+                            }
+                        }
+                        else
+                        {
+                            reply = string.Format(_stringConstant.NotTeamLeader, slackUserId);
+                        }
+                    }
+                    else
+                        reply = string.Format(_stringConstant.NotTeamLeaderOfProject, givenProjectName, slackUserId);
+                }
+                else
+                    // if user doesn't exist then this message will be shown to user
+                    reply = _stringConstant.YouAreNotInExistInOAuthServer;
+            }
+            else
+                reply = _stringConstant.OnlyPrivateChannel;
+            return reply;
+        }
+
+
+        /// <summary>
+        /// Used to link Slack Channel to OAuth Project - JJ
+        /// </summary>
+        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="givenProjectName">the project name mentioned in the slack message</param>
+        /// <param name="project">OAuth Project of the given name</param>
+        /// <returns>status message</returns>
+        private async Task<string> LinkAsync(string slackChannelId, string givenProjectName, ProjectAc project)
+        {
+            string reply = string.Empty;
+            if (project.IsActive)
+            {
+                SlackChannelDetails alreadyLinkedChannel = await _slackChannelDetailsReposirtory.FirstOrDefaultAsync(x => x.ProjectId == project.Id);
+                if (alreadyLinkedChannel == null)
+                {
+                    //add the project id to the slack channel
+                    SlackChannelDetails slackChannel = await _slackChannelRepository.GetByIdAsync(slackChannelId);
+                    if (slackChannel.ProjectId == null)
+                    {
+                        slackChannel.ProjectId = project.Id;
+                        await _slackChannelRepository.UpdateSlackChannelAsync(slackChannel);
+                        reply = string.Format(_stringConstant.ProjectLinked, givenProjectName, slackChannel.Name);
+                    }
+                    else
+                    {
+                        reply = string.Format(_stringConstant.UnLinkFirst, givenProjectName);
+                    }
+                }
+                else
+                {
+                    reply = _stringConstant.AlreadyLinked;
+                }
+            }
+            else
+            {
+                reply = _stringConstant.InActiveProject;
+            }
+            return reply;
+        }
+
+
+        /// <summary>
+        /// Used to unlink Slack Channel from OAuth Project - JJ
+        /// </summary>
+        /// <param name="slackChannelId">slack channel id from which message is send</param>
+        /// <param name="givenProjectName">the project name mentioned in the slack message</param>
+        /// <param name="project">OAuth Project of the given name</param>
+        /// <returns>status message</returns>
+        private async Task<string> UnlinkAsync(string slackChannelId, string givenProjectName, ProjectAc project)
+        {
+            string reply = string.Empty;
+
+            SlackChannelDetails slackChannel = await _slackChannelRepository.GetByIdAsync(slackChannelId);
+            if (slackChannel.ProjectId == null)
+            {
+                reply = string.Format(_stringConstant.NotLinkedYet, givenProjectName);
+            }
+            else
+            {
+                if (slackChannel.ProjectId == project.Id)
+                {
+                    slackChannel.ProjectId = null;
+                    await _slackChannelRepository.UpdateSlackChannelAsync(slackChannel);
+                    reply = string.Format(_stringConstant.UnlinkedSuccessfully, givenProjectName, slackChannel.Name);
+                }
+                else
+                {
+                    reply = string.Format(_stringConstant.NotLinkedToChannel, givenProjectName);
+                }
+            }
+            return reply;
+        }
+
+
+        /// <summary>
+        /// Used to fetch list of Active OAuth projects in which the user is team leader and their linked slack channels - JJ
+        /// </summary>
+        /// <param name="slackUserId">UserId of slack user</param>
+        /// <returns>List of Active OAuth projects in which the user is team leader and their linked slack channels</returns>
+        private async Task<string> ListLinkAsync(string slackUserId)
+        {
+            string reply = string.Empty;
+            var accessToken = await GetAccessToken(slackUserId);
+            if (accessToken != null)
+            {
+                ApplicationUser appUser = await _applicationUser.FirstAsync(x => x.SlackUserId == slackUserId);
+                List<ProjectAc> projectList = await _oauthCallsRepository.GetListOfProjectsEnrollmentOfUserByUserIdAsync(appUser.Id, accessToken);
+                List<SlackChannelDetails> slackChannelList = _slackChannelDetailsReposirtory.FetchAsync(x => !x.Deleted).Result.ToList();
+
+                projectList.Where(y => y.IsActive && y.TeamLeader != null && y.TeamLeader.IsActive && y.TeamLeaderId == appUser.Id)
+                    .Select(proj => new
+                    {
+                        SlackChannel = slackChannelList.FirstOrDefault(x => x.ProjectId == proj.Id),
+                        ProjectName = proj.Name
+                    }).ToList().ForEach(x =>
+                    {
+                        reply += Environment.NewLine + "*" + x.ProjectName + (x.SlackChannel != null ? "* - `" + x.SlackChannel.Name + "`" : "* - none") + Environment.NewLine;
+                    });
+
+                if (string.IsNullOrEmpty(reply))
+                {
+                    reply = _stringConstant.NoLinks;
+                }
+                else
+                {
+                    reply =_stringConstant.Links + Environment.NewLine + reply;
+                }
+            }
+            else
+                // if user doesn't exist then this message will be shown to user
+                reply = _stringConstant.YouAreNotInExistInOAuthServer;
+            return reply;
+        }
+
+
+        #endregion
+    }
+}

--- a/Slack.Automation/Promact.Core.Repository/ScrumSetUpRepository/ScrumSetUpRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ScrumSetUpRepository/ScrumSetUpRepository.cs
@@ -66,9 +66,8 @@ namespace Promact.Core.Repository.ScrumSetUpRepository
         public async Task<string> ProcessSetUpMessagesAsync(string slackUserId, SlackChannelDetails slackChannel, string message)
         {
             if (String.Compare(message, _stringConstant.ListLinks, StringComparison.OrdinalIgnoreCase) == 0)
-            {
                 return await ListLinkAsync(slackUserId);
-            }
+
             else
             {
                 string[] messageArray = message.Split(null);
@@ -178,24 +177,20 @@ namespace Promact.Core.Repository.ScrumSetUpRepository
                             {
                                 //command to link
                                 if (String.Compare(command, _stringConstant.Link, StringComparison.OrdinalIgnoreCase) == 0)
-                                {
                                     reply = await LinkAsync(slackChannelId, givenProjectName, project);
-                                }
+
                                 //command to unlink
                                 else if (String.Compare(command, _stringConstant.Unlink, StringComparison.OrdinalIgnoreCase) == 0)
-                                {
                                     reply = await UnlinkAsync(slackChannelId, givenProjectName, project);
-                                }
+
                             }
                             else
-                            {
                                 reply = string.Format(_stringConstant.NotActiveUser, slackUserId);
-                            }
+
                         }
                         else
-                        {
                             reply = string.Format(_stringConstant.NotTeamLeader, slackUserId);
-                        }
+
                     }
                     else
                         reply = string.Format(_stringConstant.NotTeamLeaderOfProject, givenProjectName, slackUserId);
@@ -234,19 +229,16 @@ namespace Promact.Core.Repository.ScrumSetUpRepository
                         reply = string.Format(_stringConstant.ProjectLinked, givenProjectName, slackChannel.Name);
                     }
                     else
-                    {
                         reply = string.Format(_stringConstant.UnLinkFirst, givenProjectName);
-                    }
+
                 }
                 else
-                {
                     reply = _stringConstant.AlreadyLinked;
-                }
+
             }
             else
-            {
                 reply = _stringConstant.InActiveProject;
-            }
+
             return reply;
         }
 
@@ -264,9 +256,8 @@ namespace Promact.Core.Repository.ScrumSetUpRepository
 
             SlackChannelDetails slackChannel = await _slackChannelRepository.GetByIdAsync(slackChannelId);
             if (slackChannel.ProjectId == null)
-            {
                 reply = string.Format(_stringConstant.NotLinkedYet, givenProjectName);
-            }
+
             else
             {
                 if (slackChannel.ProjectId == project.Id)
@@ -276,9 +267,8 @@ namespace Promact.Core.Repository.ScrumSetUpRepository
                     reply = string.Format(_stringConstant.UnlinkedSuccessfully, givenProjectName, slackChannel.Name);
                 }
                 else
-                {
                     reply = string.Format(_stringConstant.NotLinkedToChannel, givenProjectName);
-                }
+
             }
             return reply;
         }
@@ -310,13 +300,11 @@ namespace Promact.Core.Repository.ScrumSetUpRepository
                     });
 
                 if (string.IsNullOrEmpty(reply))
-                {
                     reply = _stringConstant.NoLinks;
-                }
+
                 else
-                {
-                    reply =_stringConstant.Links + Environment.NewLine + reply;
-                }
+                    reply = _stringConstant.Links + Environment.NewLine + reply;
+
             }
             else
                 // if user doesn't exist then this message will be shown to user

--- a/Slack.Automation/Promact.Core.Repository/SlackChannelRepository/SlackChannelRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/SlackChannelRepository/SlackChannelRepository.cs
@@ -9,16 +9,16 @@ namespace Promact.Core.Repository.SlackChannelRepository
 
         #region Private Variable
 
-        private readonly IRepository<SlackChannelDetails> _slackChannelDetailsReposirtory;
-        
+        private readonly IRepository<SlackChannelDetails> _slackChannelDetailsRepository;
+
         #endregion
 
 
         #region Constructor
 
-        public SlackChannelRepository(IRepository<SlackChannelDetails> slackChannelDetailsReposirtory)
+        public SlackChannelRepository(IRepository<SlackChannelDetails> slackChannelDetailsRepository)
         {
-            _slackChannelDetailsReposirtory = slackChannelDetailsReposirtory;
+            _slackChannelDetailsRepository = slackChannelDetailsRepository;
         }
 
         #endregion
@@ -33,8 +33,8 @@ namespace Promact.Core.Repository.SlackChannelRepository
         /// <param name="slackChannelDetails">object of SlackChannelDetails</param>
         public async Task AddSlackChannelAsync(SlackChannelDetails slackChannelDetails)
         {
-            _slackChannelDetailsReposirtory.Insert(slackChannelDetails);
-            await _slackChannelDetailsReposirtory.SaveChangesAsync();
+            _slackChannelDetailsRepository.Insert(slackChannelDetails);
+            await _slackChannelDetailsRepository.SaveChangesAsync();
         }
 
 
@@ -45,7 +45,7 @@ namespace Promact.Core.Repository.SlackChannelRepository
         /// <returns>object of SlackChannelDetails</returns>
         public async Task<SlackChannelDetails> GetByIdAsync(string slackChannelId)
         {
-            SlackChannelDetails channel = await _slackChannelDetailsReposirtory.FirstOrDefaultAsync(x => x.ChannelId == slackChannelId);
+            SlackChannelDetails channel = await _slackChannelDetailsRepository.FirstOrDefaultAsync(x => x.ChannelId == slackChannelId);
             return channel;
         }
 
@@ -56,8 +56,8 @@ namespace Promact.Core.Repository.SlackChannelRepository
         /// <param name="slackChannelDetails">object of SlackChannelDetails</param>
         public async Task UpdateSlackChannelAsync(SlackChannelDetails slackChannelDetails)
         {
-            _slackChannelDetailsReposirtory.Update(slackChannelDetails);
-            await _slackChannelDetailsReposirtory.SaveChangesAsync();
+            _slackChannelDetailsRepository.Update(slackChannelDetails);
+            await _slackChannelDetailsRepository.SaveChangesAsync();
         }
 
 
@@ -70,8 +70,8 @@ namespace Promact.Core.Repository.SlackChannelRepository
             SlackChannelDetails channel = await GetByIdAsync(slackChannelId);
             if (channel != null)
             {
-                _slackChannelDetailsReposirtory.Delete(channel.Id);
-                await _slackChannelDetailsReposirtory.SaveChangesAsync();
+                _slackChannelDetailsRepository.Delete(channel.Id);
+                await _slackChannelDetailsRepository.SaveChangesAsync();
             }
         }
 

--- a/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
+++ b/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
@@ -34,6 +34,7 @@ using Promact.Core.Repository.ServiceRepository;
 using Promact.Core.Repository.TaskMailReportRepository;
 using Promact.Core.Repository.MailSettingRepository;
 using Promact.Core.Repository.MailSettingDetailsByProjectAndModule;
+using Promact.Core.Repository.ScrumSetUpRepository;
 using Promact.Core.Repository.GroupRepository;
 using Promact.Core.Repository.ScrumSetUpRepository;
 

--- a/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
+++ b/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
@@ -34,6 +34,7 @@ using Promact.Core.Repository.ServiceRepository;
 using Promact.Core.Repository.TaskMailReportRepository;
 using Promact.Core.Repository.MailSettingRepository;
 using Promact.Core.Repository.MailSettingDetailsByProjectAndModule;
+using Promact.Core.Repository.ScrumSetUpRepository;
 using Promact.Core.Repository.GroupRepository;
 
 namespace Promact.Core.Test
@@ -58,6 +59,7 @@ namespace Promact.Core.Test
             builder.RegisterGeneric(typeof(Repository<>)).As(typeof(IRepository<>));
             builder.RegisterType<LeaveRequestRepository>().As<ILeaveRequestRepository>();
             builder.RegisterType<ScrumBotRepository>().As<IScrumBotRepository>();
+            builder.RegisterType<ScrumSetUpRepository>().As<IScrumSetUpRepository>();
             builder.RegisterType<LeaveReportRepository>().As<ILeaveReportRepository>();
             builder.RegisterType<ScrumReportRepository>().As<IScrumReportRepository>();
             builder.RegisterType<OAuthLoginRepository>().As<IOAuthLoginRepository>();

--- a/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
+++ b/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
@@ -35,6 +35,7 @@ using Promact.Core.Repository.BaseRepository;
 using Promact.Core.Repository.TaskMailReportRepository;
 using Promact.Core.Repository.MailSettingRepository;
 using Promact.Core.Repository.MailSettingDetailsByProjectAndModule;
+using Promact.Core.Repository.ScrumSetUpRepository;
 
 namespace Promact.Core.Test
 {
@@ -58,6 +59,7 @@ namespace Promact.Core.Test
             builder.RegisterGeneric(typeof(Repository<>)).As(typeof(IRepository<>));
             builder.RegisterType<LeaveRequestRepository>().As<ILeaveRequestRepository>();
             builder.RegisterType<ScrumBotRepository>().As<IScrumBotRepository>();
+            builder.RegisterType<ScrumSetUpRepository>().As<IScrumSetUpRepository>();
             builder.RegisterType<LeaveReportRepository>().As<ILeaveReportRepository>();
             builder.RegisterType<ScrumReportRepository>().As<IScrumReportRepository>();
             builder.RegisterType<OAuthLoginRepository>().As<IOAuthLoginRepository>();

--- a/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
+++ b/Slack.Automation/Promact.Core.Test/AutofacConfig.cs
@@ -35,6 +35,7 @@ using Promact.Core.Repository.TaskMailReportRepository;
 using Promact.Core.Repository.MailSettingRepository;
 using Promact.Core.Repository.MailSettingDetailsByProjectAndModule;
 using Promact.Core.Repository.GroupRepository;
+using Promact.Core.Repository.ScrumSetUpRepository;
 
 namespace Promact.Core.Test
 {
@@ -58,6 +59,7 @@ namespace Promact.Core.Test
             builder.RegisterGeneric(typeof(Repository<>)).As(typeof(IRepository<>));
             builder.RegisterType<LeaveRequestRepository>().As<ILeaveRequestRepository>();
             builder.RegisterType<ScrumBotRepository>().As<IScrumBotRepository>();
+            builder.RegisterType<ScrumSetUpRepository>().As<IScrumSetUpRepository>();
             builder.RegisterType<LeaveReportRepository>().As<ILeaveReportRepository>();
             builder.RegisterType<ScrumReportRepository>().As<IScrumReportRepository>();
             builder.RegisterType<OAuthLoginRepository>().As<IOAuthLoginRepository>();

--- a/Slack.Automation/Promact.Core.Test/OauthCallsRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/OauthCallsRepositoryTest.cs
@@ -305,7 +305,7 @@ namespace Promact.Core.Test
             var requestProjectUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, testProjectId, _stringConstant.GetProjectDetails);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, requestProjectUrl, _stringConstant.AccessTokenForTest)).Returns(responseProject);
             var project = await _oauthCallHttpContextRepository.GetProjectDetailsAsync(testProjectId);
-            Assert.Equal(2, project.ApplicationUsers.Count);
+            Assert.Equal(2, project.Users.Count);
         }
 
         /// <summary>

--- a/Slack.Automation/Promact.Core.Test/Promact.Core.Test.csproj
+++ b/Slack.Automation/Promact.Core.Test/Promact.Core.Test.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScrumBotRepositoryTest.cs" />
     <Compile Include="ScrumReportRepositoryTest.cs" />
+    <Compile Include="ScrumSetUpRepositoryTest.cs" />
     <Compile Include="SlackChannelRepositoryTest.cs" />
     <Compile Include="SlackRepositoryTest.cs" />
     <Compile Include="SlackUserRepositoryTest.cs" />

--- a/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
@@ -176,10 +176,6 @@ namespace Promact.Core.Test
             await _userManager.CreateAsync(user);
             await _userManager.AddLoginAsync(user.Id, info);
 
-            //var userResponse = Task.FromResult(_stringConstant.EmployeesListFromOauthInValid);
-            //string userRequestUrl = string.Format("{0}{1}", _stringConstant.UsersDetailByChannelNameUrl, _stringConstant.GroupName);
-            //_mockHttpClient.Setup(x => x.GetAsync(_stringConstant.UserUrl, userRequestUrl, _stringConstant.AccessTokenForTest)).Returns(userResponse);
-
             var projectResponse = Task.FromResult(_stringConstant.ProjectDetailsFromOauthInValidUser);
             string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, _stringConstant.StringValueOneForTest);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
@@ -417,10 +413,6 @@ namespace Promact.Core.Test
             string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, _stringConstant.StringValueOneForTest);
             _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
 
-            //var usersListResponse = Task.FromResult(_stringConstant.EmployeesListInValid);
-            //string usersListRequestUrl = string.Format("{0}{1}", _stringConstant.UsersDetailByChannelNameUrl, _stringConstant.GroupName);
-            //_mockHttpClient.Setup(x => x.GetAsync(_stringConstant.UserUrl, usersListRequestUrl, _stringConstant.AccessTokenForTest)).Returns(usersListResponse);
-
             await _botQuestionRepository.AddQuestionAsync(question);
             _scrumDataRepository.Insert(scrum);
             await _scrumDataRepository.SaveChangesAsync();
@@ -464,7 +456,7 @@ namespace Promact.Core.Test
             string compareString = string.Format(_stringConstant.UserNotInProject, _stringConstant.UserNameForTest) + string.Format(_stringConstant.QuestionToNextEmployee, _stringConstant.TestUser) + Environment.NewLine;
             Assert.Equal(compareString, actualString);
         }
-                  
+
 
         /// <summary>
         /// Method StartScrum Testing with existing scrum and in-active users
@@ -527,40 +519,6 @@ namespace Promact.Core.Test
             string expectedString = _stringConstant.ScrumNotHalted + Environment.NewLine + string.Format(_stringConstant.UserNotInProject, _stringConstant.TestUser) + string.Format(_stringConstant.InActiveInOAuth, _stringConstant.UserNameForTest) + _stringConstant.ScrumComplete;
             Assert.Equal(expectedString, actualString);
         }
-
-        //not required
-        ///// <summary>
-        ///// Method StartScrum Testing with in-active users
-        ///// </summary>
-        //[Fact, Trait("Category", "Required")]
-        //public async Task ScrumInitiateHasInActiveUser()
-        //{
-        //    await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
-        //    await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
-        //    await _slackUserRepository.AddSlackUserAsync(testSlackUserDetails);
-
-        //    UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
-        //    await _userManager.CreateAsync(testUser);
-        //    await _userManager.AddLoginAsync(testUser.Id, info);
-
-        //    UserLoginInfo infor = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
-        //    await _userManager.CreateAsync(user);
-        //    await _userManager.AddLoginAsync(user.Id, infor);
-
-        //    var projectResponse = Task.FromResult(_stringConstant.ProjectDetailsFromOauthInActiveUser);
-        //    string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, _stringConstant.StringValueOneForTest);
-        //    _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
-
-        //    await _botQuestionRepository.AddQuestionAsync(question);
-        //    _scrumDataRepository.Insert(scrum);
-        //    await _scrumDataRepository.SaveChangesAsync();
-        //    _scrumAnswerDataRepository.Insert(scrumAnswer);
-        //    await _scrumAnswerDataRepository.SaveChangesAsync();
-        //    await _scrumBotRepository.AddTemporaryScrumDetailsAsync(1, _stringConstant.StringIdForTest, 0, question.Id);
-        //    string actualString = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.StartBot, _stringConstant.ScrumBotName);
-        //    string expectedString = string.Format(_stringConstant.InActiveInOAuth, testSlackUserDetails.Name) + string.Format(_stringConstant.QuestionToNextEmployee, _stringConstant.TestUser) + Environment.NewLine;
-        //    Assert.Equal(expectedString, actualString);
-        //}
 
 
         #endregion
@@ -676,33 +634,6 @@ namespace Promact.Core.Test
             string actualString = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.StringIdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.ScrumHalt, _stringConstant.ScrumBotName);
             Assert.Equal(_stringConstant.NoEmployeeFound, actualString);
         }
-
-        //repair
-        ///// <summary>
-        ///// Scrum halt Testing with no users
-        ///// </summary>
-        //[Fact, Trait("Category", "Required")]
-        //public async Task ScrumHaltTeamLeader()
-        //{
-        //    await AddChannelUserAsync();
-
-        //    UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
-        //    user.Id = _stringConstant.TeamLeaderIdForTest;
-        //    await _userManager.CreateAsync(user);
-        //    await _userManager.AddLoginAsync(user.Id, info);
-
-        //    var projectResponse = Task.FromResult(_stringConstant.ProjectDetailsFromOauth);
-        //    string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, _stringConstant.StringValueOneForTest);
-        //    _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
-
-        //    await _botQuestionRepository.AddQuestionAsync(question);
-        //    scrum.IsHalted = true;
-        //    _scrumDataRepository.Insert(scrum);
-        //    await _scrumDataRepository.SaveChangesAsync();
-
-        //    string actualString = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.StringIdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.ScrumHalt, _stringConstant.ScrumBotName);
-        //    Assert.Equal(_stringConstant.NoEmployeeFound + _stringConstant.ScrumCannotBeHalted, actualString);
-        //}
 
 
         /// <summary>
@@ -995,7 +926,6 @@ namespace Promact.Core.Test
         }
 
 
-        //not required
         /// <summary>
         /// Method Leave Testing with halted scrum
         /// </summary>
@@ -1359,33 +1289,6 @@ namespace Promact.Core.Test
         }
 
 
-        //repair use it for something else
-        ///// <summary>
-        ///// Method Leave Testing with first user left to answer one question but not an active user now
-        ///// </summary>
-        //[Fact, Trait("Category", "Required")]
-        //public async Task LeaveFirstUserOneAnswerLeftScrumComplete()
-        //{
-        //    await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
-        //    await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
-        //    testSlackUserDetails.UserId = _stringConstant.ThirdUserSlackUserId;
-        //    await _slackUserRepository.AddSlackUserAsync(testSlackUserDetails);
-
-        //    await InActiveUserProjectSetup();
-
-        //    await _botQuestionRepository.AddQuestionAsync(question);
-        //    await _botQuestionRepository.AddQuestionAsync(question1);
-        //    _scrumDataRepository.Insert(scrum);
-        //    await _scrumDataRepository.SaveChangesAsync();
-        //    _scrumAnswerDataRepository.Insert(scrumAnswer);
-        //    await _scrumAnswerDataRepository.SaveChangesAsync();
-        //    await _scrumBotRepository.AddTemporaryScrumDetailsAsync(1, _stringConstant.ThirdUserSlackUserId, 0, question.Id);
-        //    string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.StringIdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.Leave + " <@" + _stringConstant.StringIdForTest + ">", _stringConstant.ScrumBotName);
-        //    string expected = string.Format(_stringConstant.UserNotInProject, _stringConstant.UserNameForTest) + string.Format(_stringConstant.InActiveInOAuth, _stringConstant.TestUser) + _stringConstant.ScrumComplete;
-        //    Assert.Equal(expected, actual);
-        //}
-
-
         /// <summary>
         /// Method Leave Testing with the leave applicant not in project
         /// </summary>
@@ -1570,7 +1473,6 @@ namespace Promact.Core.Test
         }
 
 
-        //not required
         /// <summary>
         /// Method AddScrumAnswer Testing with normal conversation on slack channel
         /// </summary>
@@ -1592,7 +1494,6 @@ namespace Promact.Core.Test
         #region ProcessMessagesAsync Test Cases
 
 
-        //not required
         /// <summary>
         /// Method ProcessMessagesAsync Testing with scrum help
         /// </summary>
@@ -1606,7 +1507,6 @@ namespace Promact.Core.Test
         }
 
 
-        //not required
         /// <summary>
         /// Method ProcessMessagesAsync Testing with not registered channel
         /// </summary>
@@ -1625,7 +1525,6 @@ namespace Promact.Core.Test
         #region AddChannel Test Cases
 
 
-        //not required
         /// <summary>
         /// Method AddChannelManually Testing
         /// </summary>
@@ -1654,7 +1553,6 @@ namespace Promact.Core.Test
         }
 
 
-        //future
         /// <summary>
         /// Method AddChannelManually Testing with No User
         /// </summary>
@@ -1666,6 +1564,133 @@ namespace Promact.Core.Test
             Assert.Equal(_stringConstant.YouAreNotInExistInOAuthServer, actual);
         }
 
+
+        #endregion
+
+
+        #region Link Channel
+
+
+        /// <summary>
+        /// Method List links Testing 
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task ListLink()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            slackUserDetails.UserId = _stringConstant.IdForTest;
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            testSlackUserDetails.UserId = _stringConstant.StringIdForTest;
+            await _slackUserRepository.AddSlackUserAsync(testSlackUserDetails);
+
+            UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(testUser);
+            await _userManager.AddLoginAsync(testUser.Id, info);
+
+            await UserProjectSetup();
+
+            await _botQuestionRepository.AddQuestionAsync(question);
+            _scrumDataRepository.Insert(scrum);
+            await _scrumDataRepository.SaveChangesAsync();
+            await _scrumBotRepository.AddTemporaryScrumDetailsAsync(1, _stringConstant.StringIdForTest, 0, question.Id);
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.ListLinks, _stringConstant.ScrumBotName);
+            Assert.Equal(_stringConstant.NoLinks, actual);
+        }
+
+
+        /// <summary>
+        /// Method link channel with wrong command
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelWrongCommand()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            slackUserDetails.UserId = _stringConstant.IdForTest;
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            testSlackUserDetails.UserId = _stringConstant.StringIdForTest;
+            await _slackUserRepository.AddSlackUserAsync(testSlackUserDetails);
+
+            UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(testUser);
+            await _userManager.AddLoginAsync(testUser.Id, info);
+
+            await UserProjectSetup();
+
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.LinkTest + _stringConstant.NameClaimType, _stringConstant.ScrumBotName);
+            Assert.Empty(actual);
+        }
+
+
+        /// <summary>
+        /// Method link channel with wrong command but channel not linked yet
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelWrongCommandChannelNotLinked()
+        {
+            slackChannelDetails.ProjectId = null;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            slackUserDetails.UserId = _stringConstant.IdForTest;
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            testSlackUserDetails.UserId = _stringConstant.StringIdForTest;
+            await _slackUserRepository.AddSlackUserAsync(testSlackUserDetails);
+
+            UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(testUser);
+            await _userManager.AddLoginAsync(testUser.Id, info);
+
+            await UserProjectSetup();
+
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, "link \"\"", _stringConstant.ScrumBotName);
+            Assert.Equal(_stringConstant.ProjectChannelNotLinked, actual);
+        }
+
+
+        /// <summary>
+        /// Method List links Testing 
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelNoUser()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.LinkTest + _stringConstant.NameClaimType, _stringConstant.ScrumBotName);
+            Assert.Empty(actual);
+        }
+
+
+        /// <summary>
+        /// Method List links Testing 
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelNoUserValidCommand()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.ListLinks, _stringConstant.ScrumBotName);
+            Assert.Equal(_stringConstant.SlackUserNotFound, actual);
+        }
+
+
+        /// <summary>
+        /// Method link channel no channel Testing 
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelNoUserNoChannel()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, "link \"\"", _stringConstant.ScrumBotName);
+            Assert.Empty(actual);
+        }
+
+
+        /// <summary>
+        /// Method link channel no channel Testing 
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelNoUserHasChannel()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.IdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.LinkTest, _stringConstant.ScrumBotName);
+            Assert.Equal(_stringConstant.SlackUserNotFound, actual);
+        }
 
         #endregion
 

--- a/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumBotRepositoryTest.cs
@@ -748,7 +748,7 @@ namespace Promact.Core.Test
             await _scrumBotRepository.AddTemporaryScrumDetailsAsync(1, _stringConstant.IdForTest, 0, question.Id);
 
             string actualString = await _scrumBotRepository.ProcessMessagesAsync(_stringConstant.StringIdForTest, _stringConstant.SlackChannelIdForTest, _stringConstant.ScrumResume, _stringConstant.ScrumBotName);
-            string compareString = _stringConstant.ScrumNotHalted + string.Format(_stringConstant.UserNotInProject, _stringConstant.UserNameForTest) + string.Format(_stringConstant.QuestionToNextEmployee, _stringConstant.TestUser) + Environment.NewLine;
+            string compareString = _stringConstant.ScrumNotHalted + string.Format(_stringConstant.InActiveInOAuth, _stringConstant.UserNameForTest) + string.Format(_stringConstant.QuestionToNextEmployee, _stringConstant.TestUser) + Environment.NewLine;
             Assert.Equal(compareString, actualString);
         }
 

--- a/Slack.Automation/Promact.Core.Test/ScrumReportRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumReportRepositoryTest.cs
@@ -221,8 +221,7 @@ namespace Promact.Core.Test
         /// A method is used to initialize variables which are repetitively used
         /// </summary>
         public void Initialize()
-        {
-            scrum.SlackChannelId = _stringConstant.TestGroupName;
+        {           
             scrum.ScrumDate = new DateTime(2016, 9, 19);
             scrum.ProjectId = 1012;
             scrum.TeamLeaderId = _stringConstant.TestId;

--- a/Slack.Automation/Promact.Core.Test/ScrumReportRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumReportRepositoryTest.cs
@@ -218,8 +218,7 @@ namespace Promact.Core.Test
         /// A method is used to initialize variables which are repetitively used
         /// </summary>
         public void Initialize()
-        {
-            scrum.SlackChannelId = _stringConstant.TestGroupName;
+        {           
             scrum.ScrumDate = new DateTime(2016, 9, 19);
             scrum.ProjectId = 1012;
             scrum.TeamLeaderId = _stringConstant.TestId;

--- a/Slack.Automation/Promact.Core.Test/ScrumSetUpRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/ScrumSetUpRepositoryTest.cs
@@ -1,0 +1,481 @@
+﻿using Autofac;
+using Moq;
+using Promact.Core.Repository.BotQuestionRepository;
+using Promact.Erp.DomainModel.Models;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Promact.Erp.DomainModel.DataRepository;
+using Microsoft.AspNet.Identity;
+using Promact.Core.Repository.SlackUserRepository;
+using Promact.Core.Repository.SlackChannelRepository;
+using Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse;
+using Promact.Erp.Util.StringConstants;
+using Promact.Erp.Util.HttpClient;
+using Promact.Core.Repository.ServiceRepository;
+using Promact.Core.Repository.ScrumSetUpRepository;
+
+namespace Promact.Core.Test
+{
+    public class ScrumSetUpRepositoryTest
+    {
+
+        #region Private Variables
+
+
+        private readonly IComponentContext _componentContext;
+        private readonly Mock<IHttpClientService> _mockHttpClient;
+        private readonly ApplicationUserManager _userManager;
+
+        private readonly IScrumSetUpRepository _scrumSetUpRepository;
+        private readonly ISlackUserRepository _slackUserRepository;
+        private readonly ISlackChannelRepository _slackChannelReposiroty;
+        private readonly IStringConstantRepository _stringConstant;
+        private readonly Mock<IServiceRepository> _mockServiceRepository;
+
+
+
+        private SlackProfile profile = new SlackProfile();
+
+        private SlackUserDetails slackUserDetails = new SlackUserDetails();
+        private SlackUserDetails testSlackUserDetails = new SlackUserDetails();
+        private SlackChannelDetails slackChannelDetails = new SlackChannelDetails();
+        private ApplicationUser user = new ApplicationUser();
+
+
+        #endregion
+
+
+        #region Constructor
+
+
+        public ScrumSetUpRepositoryTest()
+        {
+            _componentContext = AutofacConfig.RegisterDependancies();
+
+            _scrumSetUpRepository = _componentContext.Resolve<IScrumSetUpRepository>();
+            _mockHttpClient = _componentContext.Resolve<Mock<IHttpClientService>>();
+            _userManager = _componentContext.Resolve<ApplicationUserManager>();
+            _slackUserRepository = _componentContext.Resolve<ISlackUserRepository>();
+            _slackChannelReposiroty = _componentContext.Resolve<ISlackChannelRepository>();
+            _stringConstant = _componentContext.Resolve<IStringConstantRepository>();
+            _mockServiceRepository = _componentContext.Resolve<Mock<IServiceRepository>>();
+            Initialization();
+
+        }
+        #endregion
+
+
+        #region Initialization
+
+
+        /// <summary>
+        /// A method is used to initialize variables which are repetitively used
+        /// </summary>
+        public void Initialization()
+        {
+            user.Id = _stringConstant.StringIdForTest;
+            user.Email = _stringConstant.EmailForTest;
+            user.UserName = _stringConstant.EmailForTest;
+            user.SlackUserId = _stringConstant.StringIdForTest;
+
+            profile.Skype = _stringConstant.TestUserId;
+            profile.Email = _stringConstant.EmailForTest;
+            profile.FirstName = _stringConstant.UserNameForTest;
+            profile.LastName = _stringConstant.TestUser;
+            profile.Phone = _stringConstant.PhoneForTest;
+            profile.Title = _stringConstant.UserNameForTest;
+
+            slackUserDetails.UserId = _stringConstant.StringIdForTest;
+            slackUserDetails.Name = _stringConstant.TestUser;
+            slackUserDetails.TeamId = _stringConstant.PromactStringName;
+            slackUserDetails.CreatedOn = DateTime.UtcNow;
+            slackUserDetails.Deleted = false;
+            slackUserDetails.IsAdmin = false;
+            slackUserDetails.IsBot = false;
+            slackUserDetails.IsPrimaryOwner = false;
+            slackUserDetails.IsOwner = false;
+            slackUserDetails.IsRestrictedUser = false;
+            slackUserDetails.IsUltraRestrictedUser = false;
+            slackUserDetails.Profile = profile;
+            slackUserDetails.RealName = _stringConstant.TestUser + _stringConstant.TestUser;
+
+            testSlackUserDetails.UserId = _stringConstant.IdForTest;
+            testSlackUserDetails.Name = _stringConstant.UserNameForTest;
+            testSlackUserDetails.TeamId = _stringConstant.PromactStringName;
+            testSlackUserDetails.Profile = profile;
+
+            slackChannelDetails.ChannelId = _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.Deleted = false;
+            slackChannelDetails.CreatedOn = DateTime.UtcNow;
+            slackChannelDetails.Name = _stringConstant.GroupName;
+            slackChannelDetails.ProjectId = 1;
+
+            var accessTokenForTest = Task.FromResult(_stringConstant.AccessTokenForTest);
+            _mockServiceRepository.Setup(x => x.GerAccessTokenByRefreshToken(_stringConstant.AccessTokenForTest)).Returns(accessTokenForTest);
+        }
+
+
+        private async Task AddChannelUserAsync()
+        {
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            await _slackUserRepository.AddSlackUserAsync(testSlackUserDetails);
+        }
+
+        private async Task InActiveUserProjectSetup()
+        {
+            UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(user);
+            await _userManager.AddLoginAsync(user.Id, info);
+
+            var projectResponse = Task.FromResult(_stringConstant.ProjectDetailsFromOauthInValidUser);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, _stringConstant.StringValueOneForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+        }
+
+        private async Task UserProjectSetup()
+        {
+            UserLoginInfo info = new UserLoginInfo(_stringConstant.PromactStringName, _stringConstant.AccessTokenForTest);
+            await _userManager.CreateAsync(user);
+            await _userManager.AddLoginAsync(user.Id, info);
+
+            var projectResponse = Task.FromResult(_stringConstant.ProjectDetailsFromOauth);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.ProjectDetailUrl, _stringConstant.StringValueOneForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+        }
+
+
+        #endregion
+
+
+        #region Test Cases
+
+
+        #region ProcessSetUpMessagesAsync Test Cases
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing for list links
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task ListLinksNotAUser()
+        {
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.ListLinks);
+            Assert.Equal(_stringConstant.YouAreNotInExistInOAuthServer, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing for no list of links
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task ListLinksNoLinks()
+        {
+            await UserProjectSetup();
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectAndTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.ListLinks);
+            Assert.Equal(_stringConstant.NoLinks, actual);
+        }
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing for list of links
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task ListLinks()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.ListLinks);
+            string expected = _stringConstant.Links + Environment.NewLine + _stringConstant.ListOfLinks;
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannel()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = null;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest);
+            string expected = string.Format(_stringConstant.ProjectLinked, _stringConstant.OAuthProjectName, _stringConstant.GroupName);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but not channel
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelNotChannel()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ProjectId = null;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest);
+            Assert.Equal(_stringConstant.OnlyPrivateChannel, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but unlink first
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelUnLinkFirst()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest);
+            string expected = string.Format(_stringConstant.UnLinkFirst, _stringConstant.OAuthProjectName);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but already linked
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelAlreadyLinked()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest);
+            Assert.Equal(_stringConstant.AlreadyLinked, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but in active project
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelProjectNotActive()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.InActiveProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest);
+            Assert.Equal(_stringConstant.InActiveProject, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but no name
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelNoName()
+        {
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkChannelNoName);
+            Assert.Null(actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but wrong command
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelWrongCommand()
+        {
+
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest + _stringConstant.NameClaimType);
+            Assert.Null(actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing linking channel but wrong command
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task LinkChannelInCorrectCommand()
+        {
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = null;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.LinkTest + _stringConstant.NameClaimType);
+            Assert.Equal(_stringConstant.ProjectChannelNotLinked, actual);
+        }
+
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel but in active team leader
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannelTeamleaderNotActive()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderInActiveDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkCommand);
+            string expected = string.Format(_stringConstant.NotActiveUser, _stringConstant.StringIdForTest);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel but not project
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannelNoProject()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 1;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderInActiveDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkTest);
+            string expected = string.Format(_stringConstant.NotTeamLeader, _stringConstant.StringIdForTest);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel but not user
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannelNotUser()
+        {
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkTest);
+            Assert.Equal(_stringConstant.YouAreNotInExistInOAuthServer, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannel()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkCommand);
+            string expected = string.Format(_stringConstant.UnlinkedSuccessfully, _stringConstant.OAuthProjectName, _stringConstant.GroupName);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel but linked to another channel
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannelLinked()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 1;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkCommand);
+            string expected = string.Format(_stringConstant.NotLinkedToChannel, _stringConstant.OAuthProjectName);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel but not linked yet
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannelNotLinked()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = null;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkCommand);
+            string expected = string.Format(_stringConstant.NotLinkedYet, _stringConstant.OAuthProjectName);
+            Assert.Equal(expected, actual);
+        }
+
+
+        /// <summary>
+        /// Method ProcessSetUpMessagesAsync Testing unlinking channel but no team leader
+        /// </summary>
+        [Fact, Trait("Category", "Required")]
+        public async Task UnLinkChannelNoTeamleader()
+        {
+            await UserProjectSetup();
+            slackChannelDetails.ChannelId = _stringConstant.GroupNameStartsWith + _stringConstant.SlackChannelIdForTest;
+            slackChannelDetails.ProjectId = 2;
+            await _slackChannelReposiroty.AddSlackChannelAsync(slackChannelDetails);
+            await _slackUserRepository.AddSlackUserAsync(slackUserDetails);
+            var projectResponse = Task.FromResult(_stringConstant.ProjectTeamLeaderInActiveDetail);
+            string projectRequestUrl = string.Format(_stringConstant.FirstAndSecondIndexStringFormat, _stringConstant.DetailsAndSlashForUrl, _stringConstant.StringIdForTest);
+            _mockHttpClient.Setup(x => x.GetAsync(_stringConstant.ProjectUrl, projectRequestUrl, _stringConstant.AccessTokenForTest)).Returns(projectResponse);
+            string actual = await _scrumSetUpRepository.ProcessSetUpMessagesAsync(_stringConstant.StringIdForTest, slackChannelDetails, _stringConstant.UnlinkTest);
+            string expected = string.Format(_stringConstant.NotTeamLeader, _stringConstant.StringIdForTest);
+            Assert.Equal(expected, actual);
+        }
+
+
+        #endregion
+
+
+        #endregion
+
+
+    }
+}

--- a/Slack.Automation/Promact.Core.Test/SlackRepositoryTest.cs
+++ b/Slack.Automation/Promact.Core.Test/SlackRepositoryTest.cs
@@ -278,7 +278,7 @@ namespace Promact.Core.Test
             MockingOfUserDetails();
             await _leaveRequestRepository.ApplyLeaveAsync(leave);
             var replyText = string.Format(_stringConstant.ReplyTextForCasualLeaveList, leave.Id, leave.Reason, leave.FromDate.ToShortDateString(), leave.EndDate.Value.ToShortDateString(), leave.Status, System.Environment.NewLine);
-            slackLeave.Text = _stringConstant.LeaveListTestForOwn;
+            slackLeave.Text = _stringConstant.List;
             var textJson = SlackReplyMethodMocking(slackLeave.ResponseUrl, replyText, _stringConstant.JsonContentString);
             MockingUserDetialFromSlackUserId();
             await _slackRepository.LeaveRequestAsync(slackLeave);
@@ -295,7 +295,7 @@ namespace Promact.Core.Test
             await AddThreeUserIncomingWebHookAsync();
             await _leaveRequestRepository.ApplyLeaveAsync(leave);
             var replyText = _stringConstant.SlashCommandLeaveStatusErrorMessage;
-            slackLeave.Text = _stringConstant.LeaveListTestForOwn;
+            slackLeave.Text = _stringConstant.List;
             var textJson = SlackReplyMethodMocking(slackLeave.ResponseUrl, replyText, _stringConstant.JsonContentString);
             await _slackRepository.LeaveRequestAsync(slackLeave);
             _mockHttpClient.Verify(x => x.PostAsync(slackLeave.ResponseUrl, textJson, _stringConstant.JsonContentString), Times.Once);

--- a/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/OAuthController.cs
@@ -35,8 +35,8 @@ namespace Promact.Erp.Core.Controllers
         #endregion
 
         #region Constructor
-        public OAuthController(IHttpClientService httpClientService, IStringConstantRepository stringConstantRepository, 
-            ISlackUserRepository slackUserRepository, ILogger logger, 
+        public OAuthController(IHttpClientService httpClientService, IStringConstantRepository stringConstantRepository,
+            ISlackUserRepository slackUserRepository, ILogger logger,
             IRepository<SlackChannelDetails> slackChannelDetails, IOAuthLoginRepository oAuthLoginRepository,
             ApplicationUserManager userManager, ISlackChannelRepository slackChannelRepository,
             IOauthCallHttpContextRespository oauthCallRepository) : base(stringConstantRepository)
@@ -52,7 +52,7 @@ namespace Promact.Erp.Core.Controllers
         }
         #endregion
 
-        #region Private Methods
+        #region Public Methods
         /**
         * @api {get} oauth/refreshtoken
         * @apiVersion 1.0.0
@@ -221,13 +221,20 @@ namespace Promact.Erp.Core.Controllers
                     eventQueue.Dequeue();
                     return Ok();
                 }
+                //when a channel or a group is archived
+                else if (eventType == _stringConstantRepository.ChannelArchive || eventType == _stringConstantRepository.GroupArchive)
+                {
+                    await _slackChannelRepository.DeleteChannelAsync(events.Event.Channel.ChannelId);
+                    eventQueue.Dequeue();
+                    return Ok();
+                }
                 else
                 {
                     eventQueue.Dequeue();
                     return Ok();
                 }
             }
-            return null;
+            return Ok();
         }
 
         /**

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/ProjectAc.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/ProjectAc.cs
@@ -18,6 +18,6 @@ namespace Promact.Erp.DomainModel.ApplicationClass
         public string UpdatedBy { get; set; }
         public string UpdatedDate { get; set; }
         public User TeamLeader { get; set; }
-        public List<User> ApplicationUsers { get; set; }
+        public List<User> Users { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/ProjectAc.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/ProjectAc.cs
@@ -1,4 +1,5 @@
 ﻿
+using Newtonsoft.Json;
 using System.Collections.Generic;
 
 namespace Promact.Erp.DomainModel.ApplicationClass
@@ -6,9 +7,9 @@ namespace Promact.Erp.DomainModel.ApplicationClass
     public class ProjectAc
     {
         public int Id { get; set; }
-       
+
         public string Name { get; set; }
-     
+
         public string SlackChannelName { get; set; }
 
         public bool IsActive { get; set; }
@@ -18,6 +19,8 @@ namespace Promact.Erp.DomainModel.ApplicationClass
         public string UpdatedBy { get; set; }
         public string UpdatedDate { get; set; }
         public User TeamLeader { get; set; }
+
+        [JsonProperty("ApplicationUsers")]
         public List<User> Users { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackChannelDetails.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackChannelDetails.cs
@@ -22,5 +22,10 @@ namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
         /// </summary>
         [JsonProperty("is_archived")]
         public bool Deleted { get; set; }
+
+        /// <summary>
+        /// Id of corresponding OAuth Project
+        /// </summary>
+        public int? ProjectId { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackEventDetailAC.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/ApplicationClass/SlackRequestAndResponse/SlackEventDetailAC.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Promact.Erp.DomainModel.JSonConverterUtil;
 
 namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
 {
@@ -9,6 +10,7 @@ namespace Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse
         [JsonProperty("user")]
         public SlackUserDetails User { get; set; }
         [JsonProperty("channel")]
+        [JsonConverter(typeof(SlackChannelDetailsConverter))]
         public SlackChannelDetails Channel { get; set; }
     }
 }

--- a/Slack.Automation/Promact.Erp.DomainModel/JSonConverterUtil/SlackChannelDetailsConverter.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/JSonConverterUtil/SlackChannelDetailsConverter.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Promact.Erp.DomainModel.ApplicationClass.SlackRequestAndResponse;
+using System;
+
+namespace Promact.Erp.DomainModel.JSonConverterUtil
+{
+
+    public class SlackChannelDetailsConverter : JsonConverter
+    {
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+                       
+
+        /// <summary>
+        /// Reads the JSON representation of the object. - JJ
+        /// </summary>
+        /// <param name="reader">The Newtonsoft.Json.JsonReader to read from</param>
+        /// <param name="objectType">Type of the object</param>
+        /// <param name="existingValue">The existing value of object being read</param>
+        /// <param name="serializer">The calling serializer</param>
+        /// <returns>The object value</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JToken token = JToken.Load(reader);
+            if (token.Type == JTokenType.Object)
+            {
+                return token.ToObject<SlackChannelDetails>();
+            }
+            else
+            {
+                SlackChannelDetails result = new SlackChannelDetails();
+                result.ChannelId = (string)token;
+                return result;
+            }
+        }
+
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+

--- a/Slack.Automation/Promact.Erp.DomainModel/Models/Scrum.cs
+++ b/Slack.Automation/Promact.Erp.DomainModel/Models/Scrum.cs
@@ -5,12 +5,7 @@ namespace Promact.Erp.DomainModel.Models
 {
     public class Scrum : ModelBase
     {
-        /// <summary>
-        /// Slack Channel Id
-        /// </summary>
-        [Required]
-        public string SlackChannelId { get; set; }
-
+       
         /// <summary>
         /// Team Leader's Id from Oauth
         /// </summary>

--- a/Slack.Automation/Promact.Erp.DomainModel/Promact.Erp.DomainModel.csproj
+++ b/Slack.Automation/Promact.Erp.DomainModel/Promact.Erp.DomainModel.csproj
@@ -159,6 +159,7 @@
     <Compile Include="ApplicationClass\EmailHashCodeAC.cs" />
     <Compile Include="ApplicationClass\UserAdminBasicDetailsAC.cs" />
     <Compile Include="ApplicationClass\UserEmailListAc.cs" />
+    <Compile Include="JSonConverterUtil\SlackChannelDetailsConverter.cs" />
     <Compile Include="Models\Group.cs" />
     <Compile Include="Models\GroupEmailMapping.cs" />
     <Compile Include="Models\MailSetting.cs" />

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
@@ -23,8 +23,20 @@
         string CancelLeaveError { get; }
         string SlackHelpMessage { get; }
         string SlackErrorMessage { get; }
-
-
+        string Link { get; }
+        string Unlink { get; }
+        string NotActiveUser { get; }
+        string NotTeamLeader { get; }
+        string ProjectLinked { get; }
+        string UnLinkFirst { get; }
+        string InActiveProject { get; }
+        string AlreadyLinked { get; }
+        string NotLinkedYet { get; }
+        string UnlinkedSuccessfully { get; }
+        string  NotLinkedToChannel { get; }
+        string NoLinks { get; }
+        string Links { get; }
+        string NotTeamLeaderOfProject { get; }
         string UsersDetailByChannelNameUrl { get; }
         string UserDetailsByIdUrl { get; }
         string UrlRtmStart { get; }
@@ -36,6 +48,7 @@
         string SlackAuthorize { get; }
         string UserCouldNotBeAdded { get; }
         string ProjectDetailsByUserNameUrl { get; }
+        string ProjectDetailUrl { get; }
         string ProjectUsersByTeamLeaderId { get; }
         string ProjectUserDetailsUrl { get; }
         string ProjectTeamLeaderDetailsUrl { get; }
@@ -44,6 +57,14 @@
         string ThankYou { get; }
         string InternalError { get; }
         string SlackUserListUrl { get; }
+        string ProjectDetailsFromOauthInValidUser { get; }
+        string ProjectDetailsFromOauthOneEmployee { get; }
+        string ProjectDetailsFromOauthOneInActiveEmployee { get; }
+
+        string ProjectDetailsFromOauthThreeEmployeeInActive { get; }
+        string ProjectDetailsFromOauthThreeEmployee { get; }
+        string ProjectChannelNotLinked { get; }
+
         string SlackChannelListUrl { get; }
         string SlackGroupListUrl { get; }
         string TaskMailBotStatusErrorMessage { get; }
@@ -76,6 +97,7 @@
         string LoggerErrorMessageOAuthControllerSlackDetailsAdd { get; }
         string PreviousDayStatus { get; }
         string PreviousDayScrumAnswer { get; }
+        string InActiveProjectDetailsFromOauthInActiveUser { get; }
         string NameFormat { get; }
         string AnswerNotRecorded { get; }
         string UserNotInOAuthOrProject { get; }
@@ -90,6 +112,7 @@
         string NoSlackDetails { get; }
         string ScrumCannotBeHalted { get; }
         string ScrumCannotBeResumed { get; }
+        string ProjectDetailsFromOauthInActiveUser { get; }
         string ProjectInActive { get; }
         string ScrumInProgress { get; }
         string EmployeesListFromOauthThreeEmployeesInActive { get; }
@@ -113,6 +136,7 @@
         string GroupArchive { get; }
         string ChannelRename { get; }
         string GroupRename { get; }
+        string ListLinks { get; }
 
         string NoProjectFound { get; }
         string ScrumComplete { get; }
@@ -234,7 +258,7 @@
         string UserDetailsResponseText { get; }
         string ChannelDetailsResponseText { get; }
         string GroupDetailsResponseText { get; }
-        string LeaveListTestForOwn { get; }
+        string List { get; }
         string WrongLeaveCancelCommandForTest { get; }
         string LeaveStatusTestForOwn { get; }
         string SecondQuestionForTest { get; }

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/IStringConstantRepository.cs
@@ -27,6 +27,9 @@
         string Unlink { get; }
         string NotActiveUser { get; }
         string NotTeamLeader { get; }
+        string ListOfLinks { get; }
+        string ProjectAndTeamLeaderDetail { get; }
+        string ProjectTeamLeaderDetail { get; }
         string ProjectLinked { get; }
         string UnLinkFirst { get; }
         string InActiveProject { get; }
@@ -184,6 +187,7 @@
         string Command { get; }
         string ResponseUrl { get; }
         string TeamDomain { get; }
+        string OAuthProjName { get; }
         string TeamId { get; }
         string Text { get; }
         string Token { get; }
@@ -193,6 +197,13 @@
         string UnderConstruction { get; }
         string Hello { get; }
         string All { get; }
+        string LinkTest { get; }
+        string LinkChannelNoName { get; }
+        string UnlinkCommand { get; }
+        string UnlinkTest { get; }
+        string ProjectTeamLeaderInActiveDetail { get; }
+        string OAuthProjectName { get; }
+        string InActiveProjectTeamLeaderDetail { get; }
         string StringHourForTest { get; }
         string AfterLogIn { get; }
         string Home { get; }

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
@@ -592,7 +592,7 @@ namespace Promact.Erp.Util.StringConstants
                 return "Project is not active in OAuth";
             }
         }
-       public string AlreadyLinked
+        public string AlreadyLinked
         {
             get
             {
@@ -943,10 +943,17 @@ namespace Promact.Erp.Util.StringConstants
                 return "Bot Not Found";
             }
         }
+        public string OAuthProjName
+        {
+            get
+            {
+                return "Sci Test Bot";
+            }
+        }
         public string StringIdForTest
         {
             get
-            {           
+            {
                 return "13b0f2ca-92f5-4713-a67e-37e50172e148";
             }
         }
@@ -1014,7 +1021,78 @@ namespace Promact.Erp.Util.StringConstants
                 return "{\"firstName\":\"siddhartha\",\"lastName\":\"Promact\",\"isActive\":false,\"numberOfCasualLeave\":10.0,\"numberOfSickLeave\":5.0,\"joiningDate\":\"0001-01-01T00:00:00\",\"slackUserId\":\"U0HJ49KJ4\",\"slackUserName\":\"siddhartha\",\"slackUserId\":\"U0HJ49KJ4\",\"projects\":null,\"createdBy\":null,\"createdDateTime\":\"0001-01-01T00:00:00\",\"updatedBy\":null,\"updatedDateTime\":\"0001-01-01T00:00:00\",\"id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"userName\":\"roshni@promactinfo.com\",\"normalizedUserName\":null,\"email\":\"roshni@promactinfo.com\",\"normalizedEmail\":null,\"emailConfirmed\":false,\"passwordHash\":null,\"securityStamp\":null,\"concurrencyStamp\":\"a39b2cff-51e2-4f1d-bde9-096cefb17497\",\"phoneNumber\":null,\"phoneNumberConfirmed\":false,\"twoFactorEnabled\":false,\"lockoutEnd\":null,\"lockoutEnabled\":false,\"accessFailedCount\":0,\"roles\":[],\"Role\":\"Management\",\"claims\":[],\"logins\":[]}";
             }
         }
+        public string ProjectAndTeamLeaderDetail
+        {
+            get
+            {
+                return "[{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[]},{\"Id\":2,\"Name\":\"Two Tester\",\"SlackChannelName\":\"twotester\",\"IsActive\":true,\"TeamLeaderId\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]},{\"Id\":3,\"Name\":\"test\",\"SlackChannelName\":\"test\",\"IsActive\":true,\"TeamLeaderId\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":null,\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]}]";
+            }
+        }
+        public string ProjectTeamLeaderDetail
+        {
+            get
+            {
+                return "[{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[]},{\"Id\":2,\"Name\":\"Two Tester\",\"SlackChannelName\":\"twotester\",\"IsActive\":true,\"TeamLeaderId\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]},{\"Id\":3,\"Name\":\"test\",\"SlackChannelName\":\"test\",\"IsActive\":true,\"TeamLeaderId\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":null,\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]}]";
+            }
+        }
+        public string ProjectTeamLeaderInActiveDetail
+        {
+            get
+            {
+                return "[{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[]},{\"Id\":2,\"Name\":\"Two Tester\",\"SlackChannelName\":\"twotester\",\"IsActive\":true,\"TeamLeaderId\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":false,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]},{\"Id\":3,\"Name\":\"test\",\"SlackChannelName\":\"test\",\"IsActive\":true,\"TeamLeaderId\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":null,\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]}]";
+            }
+        }
+        public string UnlinkCommand
+        {
+            get
+            {
+                return "unlink \"Two Tester\"";
 
+            }
+        }
+        public string UnlinkTest
+        {
+            get
+            {
+                return "unlink \"Sci bot testing\"";
+
+            }
+        }      
+        public string InActiveProjectTeamLeaderDetail
+        {
+            get
+            {
+                return "[{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[]},{\"Id\":2,\"Name\":\"Two Tester\",\"SlackChannelName\":\"twotester\",\"IsActive\":false,\"TeamLeaderId\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]},{\"Id\":3,\"Name\":\"test\",\"SlackChannelName\":\"test\",\"IsActive\":true,\"TeamLeaderId\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":null,\"UpdatedDate\":null,\"TeamLeader\":{\"Id\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},\"ApplicationUsers\":[]}]";
+            }
+        }
+        public string LinkChannelNoName
+        {
+            get
+            {
+                return "Link \"\"";
+            }
+        }
+        public string ListOfLinks
+        {
+            get
+            {
+                return "\r\n*Two Tester* - `testbotgroup`\r\n";
+            }
+        }
+        public string LinkTest
+        {
+            get
+            {
+                return "link \"Two Tester\"";
+            }
+        }
+        public string OAuthProjectName
+        {
+            get
+            {
+                return "Two Tester";
+            }
+        }
         public string SlashCommandText
         {
             get

--- a/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
+++ b/Slack.Automation/Promact.Erp.Util/StringConstants/StringConstantRepository.cs
@@ -239,6 +239,13 @@ namespace Promact.Erp.Util.StringConstants
                 return "projectByUserName/";
             }
         }
+        public string ProjectDetailUrl
+        {
+            get
+            {
+                return "projectDetail/";
+            }
+        }
         public string ProjectUsersByTeamLeaderId
         {
             get
@@ -527,6 +534,104 @@ namespace Promact.Erp.Util.StringConstants
             get
             {
                 return "leave";
+            }
+        }
+        public string Link
+        {
+            get
+            {
+                return "link";
+            }
+        }
+        public string Unlink
+        {
+            get
+            {
+                return "unlink";
+            }
+        }
+        public string NotActiveUser
+        {
+            get
+            {
+                return "<@{0}> is not active in OAuth server.";
+            }
+        }
+        public string NotTeamLeader
+        {
+            get
+            {
+                return "Sorry <@{0}> is not the team leader of this project";
+            }
+        }
+        public string NotTeamLeaderOfProject
+        {
+            get
+            {
+                return "An active project named : *{0}* with <@{1}> as team leader could not be found in OAuth";
+            }
+        }
+        public string ProjectLinked
+        {
+            get
+            {
+                return "Project *{0}* linked to `{1}` successfully";
+            }
+        }
+        public string UnLinkFirst
+        {
+            get
+            {
+                return "Please unlink slack channel first to link to *{0}*";
+            }
+        }
+        public string InActiveProject
+        {
+            get
+            {
+                return "Project is not active in OAuth";
+            }
+        }
+       public string AlreadyLinked
+        {
+            get
+            {
+                return "Project is already linked to another slack channel";
+            }
+        }
+        public string NotLinkedYet
+        {
+            get
+            {
+                return "Slack channel is not linked to *{0}* or any other OAuth projects yet.";
+            }
+        }
+        public string UnlinkedSuccessfully
+        {
+            get
+            {
+                return "Project *{0}* unlinked from `{1}` successfully";
+            }
+        }
+        public string NotLinkedToChannel
+        {
+            get
+            {
+                return "Slack channel is not linked to *{0}*";
+            }
+        }
+        public string NoLinks
+        {
+            get
+            {
+                return "No OAuth Project - Slack Channel Links to show";
+            }
+        }
+        public string Links
+        {
+            get
+            {
+                return "List of OAuth Project - Slack Channel Links :";
             }
         }
         public string Later
@@ -841,7 +946,7 @@ namespace Promact.Erp.Util.StringConstants
         public string StringIdForTest
         {
             get
-            {
+            {           
                 return "13b0f2ca-92f5-4713-a67e-37e50172e148";
             }
         }
@@ -1622,11 +1727,18 @@ namespace Promact.Erp.Util.StringConstants
                 return "{\n    \"ok\": true,\n    \"groups\": [\n        {\n            \"id\": \"G0HJ0SB9R\",\n            \"name\": \"bbit-training-group\",\n            \"is_group\": true,\n            \"created\": 1451628546,\n            \"creator\": \"U04KUAFSH\",\n            \"is_archived\": true,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U04KUAFSH\",\n                \"U051J2RTW\",\n                \"U051J5H4G\",\n                \"U051ZTH8J\",\n                \"U0525M2P1\",\n                \"U0HJ33E49\",\n                \"U0HJ34YU9\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G0RF4FM09\",\n            \"name\": \"creativecell\",\n            \"is_group\": true,\n            \"created\": 1457515586,\n            \"creator\": \"U051J3RQL\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U04K6NL6A\",\n                \"U04KUAFSH\",\n                \"U051HV7DA\",\n                \"U051HV8JE\",\n                \"U051J3RQL\",\n                \"U051ZTH8J\",\n                \"U05256USX\",\n                \"U0525LCJR\",\n                \"U0525LFLT\",\n                \"U0525MNTH\",\n                \"U0525NTFZ\",\n                \"U0525PKAK\",\n                \"U05263AL9\",\n                \"U06NVGLPQ\",\n                \"U08GCPE0J\",\n                \"U09UNVC20\",\n                \"U0FQH9DB9\",\n                \"U0H7R5MPS\",\n                \"U0HJ34YU9\",\n                \"U0HJ49KJ4\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G0MH2SCTG\",\n            \"name\": \"crozi-internal-beta\",\n            \"is_group\": true,\n            \"created\": 1455627169,\n            \"creator\": \"U04K6NL6A\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U04K6NL6A\",\n                \"U051HV8JE\",\n                \"U051J13Q8\",\n                \"U051J2QKG\",\n                \"U051J2RTW\",\n                \"U051J3RQL\",\n                \"U051J5H4G\",\n                \"U0525LDMF\",\n                \"U0525M2P1\",\n                \"U0525MNTH\",\n                \"U0525PKAK\",\n                \"U0525QHQ1\",\n                \"U05263AL9\",\n                \"U09UNVC20\",\n                \"U0FQH9DB9\",\n                \"U0HJ33E49\",\n                \"U0HJ34YU9\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G0L2PBH9N\",\n            \"name\": \"fun-day-2016\",\n            \"is_group\": true,\n            \"created\": 1454416384,\n            \"creator\": \"U0HJ49KJ4\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U051HV8JE\",\n                \"U051J0GN4\",\n                \"U0525LDMF\",\n                \"U082PJG72\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G0FG737TL\",\n            \"name\": \"house-martell\",\n            \"is_group\": true,\n            \"created\": 1448869272,\n            \"creator\": \"U082PJG72\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U051J2RTW\",\n                \"U0525LDMF\",\n                \"U0525MFND\",\n                \"U0545BH7Q\",\n                \"U082PJG72\",\n                \"U08GCPE0J\",\n                \"U0HJ49KJ4\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"discussion about olympic 2016\",\n                \"creator\": \"U082PJG72\",\n                \"last_set\": 1448869275\n            }\n        },\n        {\n            \"id\": \"G0Q387150\",\n            \"name\": \"mostcrowdedcube\",\n            \"is_group\": true,\n            \"created\": 1457006375,\n            \"creator\": \"U0HJ49KJ4\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U0FQH9DB9\",\n                \"U0HJ33E49\",\n                \"U0HJ34YU9\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\",\n                \"U0J4V5EEQ\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G20P4DY8N\",\n            \"name\": \"mpdm-ankit--gourav--rajdeep--siddhartha--ronak.shah-1\",\n            \"is_group\": true,\n            \"created\": 1470987087,\n            \"creator\": \"U0HJ49KJ4\",\n            \"is_archived\": false,\n            \"is_mpim\": true,\n            \"members\": [\n                \"U0HJ49KJ4\",\n                \"U0526N37K\",\n                \"U0HJ48P4Y\",\n                \"U1M8GSPPC\",\n                \"U0HJ34YU9\"\n            ],\n            \"topic\": {\n                \"value\": \"Group messaging\",\n                \"creator\": \"U0HJ49KJ4\",\n                \"last_set\": 1470987087\n            },\n            \"purpose\": {\n                \"value\": \"Group messaging with: @ankit @gourav @rajdeep @siddhartha @ronak.shah\",\n                \"creator\": \"U0HJ49KJ4\",\n                \"last_set\": 1470987087\n            }\n        },\n        {\n            \"id\": \"G2006M214\",\n            \"name\": \"mpdm-ankit--rajdeep--siddhartha--ronak.shah-1\",\n            \"is_group\": true,\n            \"created\": 1470822352,\n            \"creator\": \"U0526N37K\",\n            \"is_archived\": false,\n            \"is_mpim\": true,\n            \"members\": [\n                \"U0526N37K\",\n                \"U0HJ48P4Y\",\n                \"U1M8GSPPC\",\n                \"U0HJ49KJ4\"\n            ],\n            \"topic\": {\n                \"value\": \"Group messaging\",\n                \"creator\": \"U0526N37K\",\n                \"last_set\": 1470822352\n            },\n            \"purpose\": {\n                \"value\": \"Group messaging with: @ankit @rajdeep @siddhartha @ronak.shah\",\n                \"creator\": \"U0526N37K\",\n                \"last_set\": 1470822352\n            }\n        },\n        {\n            \"id\": \"G1TPX59C0\",\n            \"name\": \"mpdm-gourav--rajdeep--siddhartha-1\",\n            \"is_group\": true,\n            \"created\": 1469092626,\n            \"creator\": \"U0HJ48P4Y\",\n            \"is_archived\": false,\n            \"is_mpim\": true,\n            \"members\": [\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\",\n                \"U0HJ34YU9\"\n            ],\n            \"topic\": {\n                \"value\": \"Group messaging\",\n                \"creator\": \"U0HJ48P4Y\",\n                \"last_set\": 1469092626\n            },\n            \"purpose\": {\n                \"value\": \"Group messaging with: @gourav @rajdeep @siddhartha\",\n                \"creator\": \"U0HJ48P4Y\",\n                \"last_set\": 1469092626\n            }\n        },\n        {\n            \"id\": \"G0HLD1MBQ\",\n            \"name\": \"mpdm-parth--rahul--gourav--rajdeep--siddhartha-1\",\n            \"is_group\": true,\n            \"created\": 1451912292,\n            \"creator\": \"U0FQH9DB9\",\n            \"is_archived\": false,\n            \"is_mpim\": true,\n            \"members\": [\n                \"U0FQH9DB9\",\n                \"U0HJ33E49\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\",\n                \"U0HJ34YU9\"\n            ],\n            \"topic\": {\n                \"value\": \"Group messaging\",\n                \"creator\": \"U0FQH9DB9\",\n                \"last_set\": 1451912292\n            },\n            \"purpose\": {\n                \"value\": \"Group messaging with: @parth @rahul @gourav @rajdeep @siddhartha\",\n                \"creator\": \"U0FQH9DB9\",\n                \"last_set\": 1451912292\n            }\n        },\n        {\n            \"id\": \"G0J2SMS4B\",\n            \"name\": \"mpdm-rahul--gourav--rajdeep--siddhartha-1\",\n            \"is_group\": true,\n            \"created\": 1452315477,\n            \"creator\": \"U0HJ48P4Y\",\n            \"is_archived\": false,\n            \"is_mpim\": true,\n            \"members\": [\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\",\n                \"U0HJ33E49\",\n                \"U0HJ34YU9\"\n            ],\n            \"topic\": {\n                \"value\": \"Group messaging\",\n                \"creator\": \"U0HJ48P4Y\",\n                \"last_set\": 1452315477\n            },\n            \"purpose\": {\n                \"value\": \"Group messaging with: @rahul @gourav @rajdeep @siddhartha\",\n                \"creator\": \"U0HJ48P4Y\",\n                \"last_set\": 1452315477\n            }\n        },\n        {\n            \"id\": \"G24PWMYJ2\",\n            \"name\": \"mpdm-roshni--julie--siddhartha-1\",\n            \"is_group\": true,\n            \"created\": 1472105114,\n            \"creator\": \"U0HJ49KJ4\",\n            \"is_archived\": false,\n            \"is_mpim\": true,\n            \"members\": [\n                \"U0HJ49KJ4\",\n                \"U06NVGLPQ\",\n                \"U0525LCJR\"\n            ],\n            \"topic\": {\n                \"value\": \"Group messaging\",\n                \"creator\": \"U0HJ49KJ4\",\n                \"last_set\": 1472105114\n            },\n            \"purpose\": {\n                \"value\": \"Group messaging with: @roshni @julie @siddhartha\",\n                \"creator\": \"U0HJ49KJ4\",\n                \"last_set\": 1472105114\n            }\n        },\n        {\n            \"id\": \"G1TQRH34H\",\n            \"name\": \"promact-erp-dev\",\n            \"is_group\": true,\n            \"created\": 1469096642,\n            \"creator\": \"U0525LCJR\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U0525LCJR\",\n                \"U0526N37K\",\n                \"U06NVGLPQ\",\n                \"U0HJ34YU9\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\",\n                \"U1M8GSPPC\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"only developers\",\n                \"creator\": \"U0525LCJR\",\n                \"last_set\": 1469096645\n            }\n        },\n        {\n            \"id\": \"G05207LJY\",\n            \"name\": \"promact-team\",\n            \"is_group\": true,\n            \"created\": 1432703647,\n            \"creator\": \"U05256USX\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U04K6NL6A\",\n                \"U04KUAFSH\",\n                \"U051HV7DA\",\n                \"U051HV8JE\",\n                \"U051HV8N8\",\n                \"U051HV9KY\",\n                \"U051J094A\",\n                \"U051J0GN4\",\n                \"U051J0M2A\",\n                \"U051J13Q8\",\n                \"U051J17PA\",\n                \"U051J2QKG\",\n                \"U051J2RTW\",\n                \"U051J3RQL\",\n                \"U051J44DE\",\n                \"U051J5H4G\",\n                \"U051JE2JW\",\n                \"U051KDCAL\",\n                \"U051ZTH8J\",\n                \"U05256USX\",\n                \"U0525LCJR\",\n                \"U0525LDMF\",\n                \"U0525LF29\",\n                \"U0525LFLT\",\n                \"U0525LH1B\",\n                \"U0525LLBZ\",\n                \"U0525LW55\",\n                \"U0525M2P1\",\n                \"U0525MFND\",\n                \"U0525MNTH\",\n                \"U0525MXL3\",\n                \"U0525N6FF\",\n                \"U0525N6NB\",\n                \"U0525NC63\",\n                \"U0525NTFZ\",\n                \"U0525PKAK\",\n                \"U0525QHQ1\",\n                \"U05263AL9\",\n                \"U0526JFLM\",\n                \"U0526N37K\",\n                \"U0545BH7Q\",\n                \"U06CU2VB9\",\n                \"U06NVGLPQ\",\n                \"U082PJG72\",\n                \"U08GCPE0J\",\n                \"U08KM481G\",\n                \"U09G8CUJ3\",\n                \"U09UNVC20\",\n                \"U0FQH9DB9\",\n                \"U0H7R5MPS\",\n                \"U0HJ33E49\",\n                \"U0HJ34YU9\",\n                \"U0HJ48P4Y\",\n                \"U0HJ49KJ4\",\n                \"U0J4V5EEQ\",\n                \"U0U36HKV1\",\n                \"U0VR8DA0Y\",\n                \"U0ZH5UYSJ\",\n                \"U1C74JGTU\",\n                \"U1D6AU01F\",\n                \"U1JBA2Z5G\",\n                \"U1M83P1U0\",\n                \"U1M8GSPPC\",\n                \"U1MVA0H3M\",\n                \"U1MVBJE2X\",\n                \"U1N1CA4C8\",\n                \"U1N1P8X89\",\n                \"U1WTH2LPM\",\n                \"U1Z3M1VNJ\",\n                \"U23EZH2TW\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G1T01U11P\",\n            \"name\": \"sci-oauth-dev\",\n            \"is_group\": true,\n            \"created\": 1468914520,\n            \"creator\": \"U0525LCJR\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U04KUAFSH\",\n                \"U0525LCJR\",\n                \"U05263AL9\",\n                \"U0526N37K\",\n                \"U06NVGLPQ\",\n                \"U0H7R5MPS\",\n                \"U0HJ34YU9\",\n                \"U0HJ49KJ4\",\n                \"U1M8GSPPC\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"Team for Slack Custom Integrations + Making OAuth server\",\n                \"creator\": \"U0525LCJR\",\n                \"last_set\": 1468914522\n            }\n        },\n        {\n            \"id\": \"G2755U4P6\",\n            \"name\": \"slack-automation-mvc\",\n            \"is_group\": true,\n            \"created\": 1472709560,\n            \"creator\": \"U04KUAFSH\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U04KUAFSH\",\n                \"U0525LCJR\",\n                \"U05263AL9\",\n                \"U0526N37K\",\n                \"U06NVGLPQ\",\n                \"U0H7R5MPS\",\n                \"U0HJ34YU9\",\n                \"U0HJ49KJ4\",\n                \"U1M8GSPPC\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"This will show build status and git commits. not meant for discussing anything.\",\n                \"creator\": \"U04KUAFSH\",\n                \"last_set\": 1472709563\n            }\n        },\n        {\n            \"id\": \"G25RU420H\",\n            \"name\": \"slack-integration\",\n            \"is_group\": true,\n            \"created\": 1472451083,\n            \"creator\": \"U0526N37K\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U05263AL9\",\n                \"U0526N37K\",\n                \"U06NVGLPQ\",\n                \"U0HJ34YU9\",\n                \"U0HJ49KJ4\",\n                \"U1M8GSPPC\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        },\n        {\n            \"id\": \"G1UPC4057\",\n            \"name\": \"slash-command\",\n            \"is_group\": true,\n            \"created\": 1469441963,\n            \"creator\": \"U0HJ49KJ4\",\n            \"is_archived\": false,\n            \"is_mpim\": false,\n            \"members\": [\n                \"U0HJ49KJ4\",\n                \"U24QNPAH0\"\n            ],\n            \"topic\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            },\n            \"purpose\": {\n                \"value\": \"\",\n                \"creator\": \"\",\n                \"last_set\": 0\n            }\n        }\n    ]\n}\n";
             }
         }
-        public string LeaveListTestForOwn
+        public string List
         {
             get
             {
                 return "list";
+            }
+        }
+        public string ListLinks
+        {
+            get
+            {
+                return "list links";
             }
         }
         public string WrongLeaveCancelCommandForTest
@@ -1971,7 +2083,49 @@ namespace Promact.Erp.Util.StringConstants
         {
             get
             {
-                return "{\"id\":2,\"name\":\"testbotgroup\",\"slackChannelName\":\"testbotgroup\",\"isActive\":true,\"teamLeaderId\":\"5c84049f-f861-406d-b420-e1bf03c9e06e\",\"createdBy\":\"1bac6614-7a2b-42fa-9f18-b6a19d8e25fb\",\"createdDate\":null,\"updatedBy\":null,\"updatedDate\":null,\"teamLeader\":null,\"applicationUsers\":null}";
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectDetailsFromOauthThreeEmployee
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"aac59fbc-7835-4bd7-9080-6b6766302\",\"FirstName\":\"Nehal\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"nehal@promactinfo.com\",\"Password\":null,\"UserName\":\"nehal\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectDetailsFromOauthThreeEmployeeInActive
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"aac59fbc-7835-4bd7-9080-6b6766302\",\"FirstName\":\"Nehal\",\"LastName\":\"Promact\",\"IsActive\":false,\"Email\":\"nehal@promactinfo.com\",\"Password\":null,\"UserName\":\"nehal\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectDetailsFromOauthOneEmployee
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectDetailsFromOauthOneInActiveEmployee
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":false,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectDetailsFromOauthInValidUser
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":false,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectDetailsFromOauthInActiveUser
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":true,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":false,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
             }
         }
 
@@ -1979,7 +2133,30 @@ namespace Promact.Erp.Util.StringConstants
         {
             get
             {
-                return "{\"id\":2,\"name\":\"testbotgroup\",\"slackChannelName\":\"testbotgroup\",\"isActive\":false,\"teamLeaderId\":\"5c84049f-f861-406d-b420-e1bf03c9e06e\",\"createdBy\":\"1bac6614-7a2b-42fa-9f18-b6a19d8e25fb\",\"createdDate\":null,\"updatedBy\":null,\"updatedDate\":null,\"teamLeader\":null,\"applicationUsers\":null}";
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":false,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"63d28a0d-b0ad-4356-93c7-a0148a3038a5\",\"FirstName\":\"julie\",\"LastName\":\"julie\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-07T18:30:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"julie@promactinfo.com\",\"Password\":null,\"UserName\":\"julie@promactinfo.com\",\"UniqueName\":\"julie-julie@promactinfo.com\",\"RoleName\":null},{\"Id\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"FirstName\":\"Admin\",\"LastName\":\"Promact\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":0.0,\"NumberOfSickLeave\":0.0,\"JoiningDate\":\"0001-01-01T00:00:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"roshni@promactinfo.com\",\"Password\":null,\"UserName\":\"roshni@promactinfo.com\",\"UniqueName\":\"Admin-roshni@promactinfo.com\",\"RoleName\":null},{\"Id\":\"cb136c2c-afad-4626-932d-613c35d7773e\",\"FirstName\":\"Ronak\",\"LastName\":\"Shah\",\"IsActive\":true,\"Role\":null,\"NumberOfCasualLeave\":6.0,\"NumberOfSickLeave\":3.0,\"JoiningDate\":\"2016-11-15T00:00:00\",\"SlackUserName\":null,\"SlackUserId\":null,\"Email\":\"ronak.shah@promactinfo.com\",\"Password\":null,\"UserName\":\"ronak.shah@promactinfo.com\",\"UniqueName\":\"Ronak-ronak.shah@promactinfo.com\",\"RoleName\":null}]}";
+                //  return "{\"id\":2,\"name\":\"testbotgroup\",\"slackChannelName\":\"testbotgroup\",\"isActive\":false,\"teamLeaderId\":\"5c84049f-f861-406d-b420-e1bf03c9e06e\",\"createdBy\":\"1bac6614-7a2b-42fa-9f18-b6a19d8e25fb\",\"createdDate\":null,\"updatedBy\":null,\"updatedDate\":null,\"teamLeader\":null,\"applicationUsers\":null}";
+            }
+        }
+        //public string InActiveProjectDetailsFromOauthActiveUser
+        //{
+        //    get
+        //    {
+        //        return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":false,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
+        //        //  return "{\"id\":2,\"name\":\"testbotgroup\",\"slackChannelName\":\"testbotgroup\",\"isActive\":false,\"teamLeaderId\":\"5c84049f-f861-406d-b420-e1bf03c9e06e\",\"createdBy\":\"1bac6614-7a2b-42fa-9f18-b6a19d8e25fb\",\"createdDate\":null,\"updatedBy\":null,\"updatedDate\":null,\"teamLeader\":null,\"applicationUsers\":null}";
+        //    }
+        //}
+        public string InActiveProjectDetailsFromOauthInActiveUser
+        {
+            get
+            {
+                return "{\"Id\":1,\"Name\":\"Sci bot testing\",\"SlackChannelName\":\"scitestbot\",\"IsActive\":false,\"TeamLeaderId\":\"29c96e32-76fe-4915-bb17-b7bd987535da\",\"CreatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"CreatedDate\":\"0001-01-01T00:00:00\",\"UpdatedBy\":\"ca395fa8-dc28-4702-ab7e-2c99d8efa1eb\",\"UpdatedDate\":null,\"TeamLeader\":null,\"ApplicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":false,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
+            }
+        }
+        public string ProjectChannelNotLinked
+        {
+            get
+            {
+                return "Please contact your administrator to link slack channel with OAuth Project";
             }
         }
         public string LeaveCommand
@@ -2391,7 +2568,7 @@ namespace Promact.Erp.Util.StringConstants
         {
             get
             {
-                return "{\"Id\":\"2d5f21e0-f7e7-4027-85ad-3faf8e1bf8bf\",\"FirstName\":\"Admin\",\"LastName\":\"Promact\",\"IsActive\":true,\"Role\":\"Employee\",\"NumberOfCasualLeave\":0.0,\"NumberOfSickLeave\":0.0,\"JoiningDate\":\"0001-01-01T00:00:00\",\"SlackUserName\":\"roshni\",\"Email\":\"roshni@promactinfo.com\",\"Password\":null,\"UserName\":\"roshni@promactinfo.com\",\"UniqueName\":\"Admin-roshni@promactinfo.com\",\"RoleName\":null}";
+                return "{\"Id\":\"2d5f21e0-f7e7-4027-85ad-3faf8e1bf8bf\",\"FirstName\":\"Admin\",\"LastName\":\"Promact\",\"IsActive\":true,\"Role\":\"Employee\",\"NumberOfCasualLeave\":0.0,\"NumberOfSickLeave\":0.0,\"JoiningDate\":\"0001-01-01T00:00:00\",\"Email\":\"roshni@promactinfo.com\",\"Password\":null,\"UserName\":\"roshni@promactinfo.com\",\"UniqueName\":\"Admin-roshni@promactinfo.com\",\"RoleName\":null}";
             }
         }
         public string TeamLeaderLoginDetails
@@ -2405,7 +2582,7 @@ namespace Promact.Erp.Util.StringConstants
         {
             get
             {
-                return "{\"id\":1012,\"name\":\"xvz\",\"slackChannelName\":\"xvz\",\"isActive\":true,\"teamLeaderId\":\"01d5e634-f073-49ca-b1b6-c0b04508577b\",\"createdBy\":\"2d5f21e0-f7e7-4027-85ad-3faf8e1bf8bf\",\"createdDate\":\"2016-09-12\",\"updatedBy\":null,\"updatedDate\":null,\"teamLeader\":{\"Id\":\"01d5e634-f073-49ca-b1b6-c0b04508577b\",\"FirstName\":\"abc\",\"LastName\":\"abc\",\"IsActive\":true,\"Role\":\"TeamLeader\",\"NumberOfCasualLeave\":9.0,\"NumberOfSickLeave\":5.0,\"JoiningDate\":\"2016-07-20T00:00:00\",\"SlackUserName\":\"abc\",\"Email\":\"abc@promactinfo.com\",\"Password\":null,\"UserName\":\"abc@promactinfo.com\",\"UniqueName\":\"abc-abc@promactinfo.com\",\"RoleName\":null},\"applicationUsers\":[{\"Id\":\"2300b67f-69a1-4388-bc3e-56d638a80aaf\",\"FirstName\":\"xyz\",\"LastName\":\"XYZ\",\"IsActive\":true,\"Role\":\"Employee\",\"NumberOfCasualLeave\":14.0,\"NumberOfSickLeave\":7.0,\"JoiningDate\":\"2015-01-06T00:00:00\",\"SlackUserName\":\"xyz\",\"Email\":\"xyz@promactinfo.com\",\"Password\":null,\"UserName\":\"xyz@promactinfo.com\",\"UniqueName\":\"xyz-xyz@promactinfo.com\",\"RoleName\":null},{\"Id\":\"2d5f21e0-f7e7-4027-85ad-3faf8e1bf8bf\",\"FirstName\":\"Admin\",\"LastName\":\"Promact\",\"IsActive\":true,\"Role\":\"Employee\",\"NumberOfCasualLeave\":0.0,\"NumberOfSickLeave\":0.0,\"JoiningDate\":\"0001-01-01T00:00:00\",\"SlackUserName\":\"roshni\",\"Email\":\"roshni@promactinfo.com\",\"Password\":null,\"UserName\":\"roshni@promactinfo.com\",\"UniqueName\":\"Admin-roshni@promactinfo.com\",\"RoleName\":null}]}";
+                return "{\"id\":1012,\"name\":\"xvz\",\"slackChannelName\":\"xvz\",\"isActive\":true,\"teamLeaderId\":\"01d5e634-f073-49ca-b1b6-c0b04508577b\",\"createdBy\":\"2d5f21e0-f7e7-4027-85ad-3faf8e1bf8bf\",\"createdDate\":\"2016-09-12\",\"updatedBy\":null,\"updatedDate\":null,\"teamLeader\":{\"Id\":\"01d5e634-f073-49ca-b1b6-c0b04508577b\",\"FirstName\":\"abc\",\"LastName\":\"abc\",\"IsActive\":true,\"Role\":\"TeamLeader\",\"NumberOfCasualLeave\":9.0,\"NumberOfSickLeave\":5.0,\"JoiningDate\":\"2016-07-20T00:00:00\",\"SlackUserName\":\"abc\",\"Email\":\"abc@promactinfo.com\",\"Password\":null,\"UserName\":\"abc@promactinfo.com\",\"UniqueName\":\"abc-abc@promactinfo.com\",\"RoleName\":null},\"applicationUsers\":[{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148f\",\"FirstName\":\"Apoorva\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"apoorvapatel@promactinfo.com\",\"Password\":null,\"UserName\":\"apoorvapatel\",\"UniqueName\":\"Apoorva-apoorvapatel@promactinfo.com\"},{\"Id\":\"13b0f2ca-92f5-4713-a67e-37e50172e148\",\"FirstName\":\"Pranali\",\"LastName\":\"Promact\",\"IsActive\":true,\"Email\":\"pranali@promactinfo.com\",\"Password\":null,\"UserName\":\"pranali\",\"UniqueName\":\"Pranali-pranali@promactinfo.com\"}]}";
             }
         }
         public string ProjectDetailsForAdminFromOauth

--- a/Slack.Automation/Promact.Erp.Web/App_Start/AutofacConfig.cs
+++ b/Slack.Automation/Promact.Erp.Web/App_Start/AutofacConfig.cs
@@ -18,6 +18,7 @@ using Promact.Core.Repository.MailSettingRepository;
 using Promact.Core.Repository.OauthCallsRepository;
 using Promact.Core.Repository.ScrumReportRepository;
 using Promact.Core.Repository.ScrumRepository;
+using Promact.Core.Repository.ScrumSetUpRepository;
 using Promact.Core.Repository.ServiceRepository;
 using Promact.Core.Repository.SlackChannelRepository;
 using Promact.Core.Repository.SlackRepository;
@@ -70,6 +71,7 @@ namespace Promact.Erp.Web.App_Start
             builder.RegisterType<LeaveRequestRepository>().As<ILeaveRequestRepository>();
             builder.RegisterType<SlackRepository>().As<ISlackRepository>();
             builder.RegisterType<ScrumBotRepository>().As<IScrumBotRepository>();
+            builder.RegisterType<ScrumSetUpRepository>().As<IScrumSetUpRepository>();
             builder.RegisterType<StringConstantRepository>().As<IStringConstantRepository>();
             builder.RegisterType<Client>().As<IClient>();
             builder.RegisterType<Bot>().AsSelf();

--- a/Slack.Automation/Promact.Erp.Web/App_Start/AutofacConfig.cs
+++ b/Slack.Automation/Promact.Erp.Web/App_Start/AutofacConfig.cs
@@ -19,7 +19,8 @@ using Promact.Core.Repository.MailSettingRepository;
 using Promact.Core.Repository.OauthCallsRepository;
 using Promact.Core.Repository.ScrumReportRepository;
 using Promact.Core.Repository.ScrumRepository;
-using Promact.Core.Repository.ServiceRepository; 
+using Promact.Core.Repository.ScrumSetUpRepository;
+using Promact.Core.Repository.ServiceRepository;
 using Promact.Core.Repository.SlackChannelRepository;
 using Promact.Core.Repository.SlackRepository;
 using Promact.Core.Repository.SlackUserRepository;
@@ -72,6 +73,7 @@ namespace Promact.Erp.Web.App_Start
             builder.RegisterType<LeaveRequestRepository>().As<ILeaveRequestRepository>();
             builder.RegisterType<SlackRepository>().As<ISlackRepository>();
             builder.RegisterType<ScrumBotRepository>().As<IScrumBotRepository>();
+            builder.RegisterType<ScrumSetUpRepository>().As<IScrumSetUpRepository>();
             builder.RegisterType<StringConstantRepository>().As<IStringConstantRepository>();
             builder.RegisterType<Client>().As<IClient>();
             builder.RegisterType<Bot>().AsSelf();

--- a/Slack.Automation/Promact.Erp.Web/app/taskmail/taskmail-details/taskmail-details.html
+++ b/Slack.Automation/Promact.Erp.Web/app/taskmail/taskmail-details/taskmail-details.html
@@ -10,8 +10,6 @@
         </div>
     </div>
 
-
-
     <div class="row">
         <div class="col-md-12 col-sm-12 col-xs-12">
             <div class="x_panel">
@@ -27,14 +25,16 @@
                     </div>
                     <div *ngFor="let taskmailUser of taskMail" class="tsk-view">
                         <div class="form-group row">
-                            <label class="control-label">  Name:</label>
-                            <p>{{taskmailUser.UserName}}</p>
+                            <div class="col-md-1">
+                                <label class="control-label">  Name:</label>
+                                <p>{{taskmailUser.UserName}}</p>
+                            </div>
+                            <div class="col-md-3">
+                                <label class="control-label">  Task Mail Date:</label>
+                                <p>{{taskmailUser.CreatedOns}}</p>
+                            </div>
                         </div>
 
-                        <div class="form-group row">
-                            <label class="control-label">    Task Mail Date:</label>
-                            <p>{{taskmailUser.CreatedOns}}</p>
-                        </div>
                         <table class="table table-hover table-bordered">
                             <thead>
                                 <tr>
@@ -54,17 +54,12 @@
                                 </tr>
                             </tbody>
                         </table>
-
                     </div>
-
                     <div class="x_title"></div>
-
                     <div class="row m-0">
-
                         <button [disabled]="IsMinDate" (click)="getTaskMailPrevious(taskMail[0].UserName,taskMail[0].UserId,taskMail[0].UserRole,taskMail[0].CreatedOns)" class="btn btn-success pull-left"> Previous</button>
                         <button [disabled]="IsMaxDate" (click)="getTaskMailNext(taskMail[0].UserName,taskMail[0].UserId,taskMail[0].UserRole,taskMail[0].CreatedOns)" class="btn btn-success pull-right"> Next</button>
                     </div>
-
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes #241 , https://github.com/Promact/oauth-server/issues/290

**Files changed are:**

**1. IOauthCallsRepository.cs** - GetUsersByChannelNameAsync updated to GetProjectDetailsAsync.
**2. OauthCallsRepository.cs** - GetUsersByChannelNameAsync updated to GetProjectDetailsAsync.
**3. ScrumReportRepository.cs** - Updated code according to change in ProjectAc model.
**4. ScrumBotRepository.cs** - Updated code to remove dependency on slack channel and added linking to channel functionality
**5. IScrumSetUpRepository.cs** - Added to support linking project with channel functionality.
**6. ScrumSetUpRepository.cs** - Added to support linking project with channel functionality.
**7. OauthCallsRepositoryTest.cs** -  Updated code according to change in ProjectAc model.
**8. ScrumBotRepositoryTest.cs** - Updated and added test cases.
**9. ScrumSetUpRepositoryTest.cs** - Added test cases.
**10. ProjectAc.cs** - Added json property for ApplicationUsers.
**11. SlackChannelDetails.cs** - Added ProjectId property.
**12. Scrum.cs** - Remove SlackChannelId property.
**13. IStringConstantRepository.cs** - Added string constants.
**14. StringConstantRepository.cs** - Added string constants.