### PR TITLE
ConfigurationRepository.cs - added 2 methods to get app credential an…

### DIFF
--- a/Slack.Automation/Promact.Core.Repository/ConfigurationRepository/ConfigurationRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ConfigurationRepository/ConfigurationRepository.cs
@@ -12,13 +12,16 @@ namespace Promact.Core.Repository.ConfigurationRepository
         #region Private Variables
         private readonly IRepository<Configuration> _configurationDataRepository;
         private readonly IStringConstantRepository _stringConstant;
+        private readonly IRepository<AppCredential> _appCredentialDataRepository;
         #endregion
 
         #region Constructor
-        public ConfigurationRepository(IRepository<Configuration> configurationDataRepository, IStringConstantRepository stringConstant)
+        public ConfigurationRepository(IRepository<Configuration> configurationDataRepository,
+            IStringConstantRepository stringConstant, IRepository<AppCredential> appCredentialDataRepository)
         {
             _configurationDataRepository = configurationDataRepository;
             _stringConstant = stringConstant;
+            _appCredentialDataRepository = appCredentialDataRepository;
         }
         #endregion
 
@@ -53,6 +56,33 @@ namespace Promact.Core.Repository.ConfigurationRepository
             configStatus.ScrumOn = await StatusOfModule(_stringConstant.ScrumModule);
             configStatus.TaskOn = await StatusOfModule(_stringConstant.TaskModule);
             return configStatus;
+        }
+
+        /// <summary>
+        /// Method to get app credentials by configuration Id
+        /// </summary>
+        /// <param name="configurationId">setting configuration Id</param>
+        /// <returns>app credentials</returns>
+        public async Task<AppCredential> GetAppCredentialsByConfigurationIdAsync(int configurationId)
+        {
+            AppCredential appCredential = new AppCredential();
+            var configuration = await _configurationDataRepository.FirstOrDefaultAsync(x=>x.Id == configurationId);
+            if (configuration != null)
+            {
+                appCredential = await _appCredentialDataRepository.FirstOrDefaultAsync(x => x.Module == configuration.Module);
+            }
+            return appCredential;
+        }
+
+        /// <summary>
+        /// Method to disable configuration by configuration Id
+        /// </summary>
+        /// <param name="configurationId">setting configuration Id</param>
+        public async Task DisableAppByConfigurationIdAsync(int configurationId)
+        {
+            var configuration = await _configurationDataRepository.FirstAsync(x => x.Id == configurationId);
+            configuration.Status = false;
+            await UpdateConfigurationAsync(configuration);
         }
         #endregion
 

--- a/Slack.Automation/Promact.Core.Repository/ConfigurationRepository/IConfigurationRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ConfigurationRepository/IConfigurationRepository.cs
@@ -22,5 +22,18 @@ namespace Promact.Core.Repository.ConfigurationRepository
         /// </summary>
         /// <returns>list of status</returns>
         Task<ConfigurationStatusAC> GetAllConfigurationStatusAsync();
+
+        /// <summary>
+        /// Method to get app credentials by configuration Id
+        /// </summary>
+        /// <param name="configurationId">setting configuration Id</param>
+        /// <returns>app credentials</returns>
+        Task<AppCredential> GetAppCredentialsByConfigurationIdAsync(int configurationId);
+
+        /// <summary>
+        /// Method to disable configuration by configuration Id
+        /// </summary>
+        /// <param name="configurationId">setting configuration Id</param>
+        Task DisableAppByConfigurationIdAsync(int configurationId);
     }
 }

--- a/Slack.Automation/Promact.Erp.Core/Controllers/ConfigurationController.cs
+++ b/Slack.Automation/Promact.Erp.Core/Controllers/ConfigurationController.cs
@@ -6,6 +6,7 @@ using System.Web.Http;
 
 namespace Promact.Erp.Core.Controllers
 {
+    [Authorize]
     [RoutePrefix(BaseUrl)]
     public class ConfigurationController : BaseController
     {

--- a/Slack.Automation/Promact.Erp.Web/app/shared/stringConstant.ts
+++ b/Slack.Automation/Promact.Erp.Web/app/shared/stringConstant.ts
@@ -93,7 +93,7 @@ export class StringConstant {
     leaveModule = "leave";
     taskModule = "task";
     scrumModule = "scrum";
-    slackAppUrl = "/Home/SlackOAuthAuthorization/";
+    slackAppUrl = "/Home/SlackOAuthAuthorization?configurationId=";
     getListOfConfiguration = "getListOfConfiguration";
     updateConfiguration = "updateConfiguration";
 }


### PR DESCRIPTION
Fixes - #282 

**1. ConfigurationRepository.cs** - added 2 methods to get app credential and disable app
**2. IConfigurationRepository.cs** - added 2 methods to get app credential and disable app
**3. ConfigurationRepositoryTest.cs** - added 2 test cases for get app credential and disable app
**4. ConfigurationController.cs** - added authorize
**5. HomeController.cs** - updated SlackOAuthAuthorization
**6. stringConstant.ts** - update string slackAppUrl