### PR TITLE
Configured project in such a way that build.js in included when project is published

### DIFF
--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -1316,4 +1316,12 @@
   </Target>
   <Target Name="AfterBuild">
   </Target> -->
+  <Target Name="BuildJs">
+  <ItemGroup>
+  <_CustomFiles Include="build.js"/>
+  <FilesForPackagingFromProject Include="%(_CustomFiles.Identity)">
+  <DestinationRelativePath>%(Filename)%(Extension)</DestinationRelativePath>
+  </FilesForPackagingFromProject>
+  </ItemGroup>
+  </Target>
 </Project>

--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -1000,6 +1000,7 @@
     <Content Include="Views\Home\AfterLogIn.cshtml" />
     <Content Include="tsconfig.json" />
     <Content Include="typings.json" />
+	<None Include="Properties\PublishProfiles\Local.pubxml" />
     <Content Include="tslint.json" />
     <Content Include="StringLiteral\StringLiteral.json" />
     <Content Include="tsconfig-aot.json" />

--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -27,7 +27,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TypeScriptToolsVersion>2.1</TypeScriptToolsVersion>
-	<CopyAllFilesToSingleFolderForPackageDependsOn>
+    <CopyAllFilesToSingleFolderForPackageDependsOn>
 	BuildJs;
 	$(CopyAllFilesToSingleFolderForPackageDependsOn);      
 	</CopyAllFilesToSingleFolderForPackageDependsOn>
@@ -1000,7 +1000,6 @@
     <Content Include="Views\Home\AfterLogIn.cshtml" />
     <Content Include="tsconfig.json" />
     <Content Include="typings.json" />
-	<None Include="Properties\PublishProfiles\Local.pubxml" />
     <Content Include="tslint.json" />
     <Content Include="StringLiteral\StringLiteral.json" />
     <Content Include="tsconfig-aot.json" />

--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -1003,7 +1003,6 @@
     <Content Include="tslint.json" />
     <Content Include="StringLiteral\StringLiteral.json" />
     <Content Include="tsconfig-aot.json" />
-    <None Include="Properties\PublishProfiles\Promact.ERP.pubxml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -1000,7 +1000,6 @@
     <Content Include="Views\Home\AfterLogIn.cshtml" />
     <Content Include="tsconfig.json" />
     <Content Include="typings.json" />
-    <None Include="Properties\PublishProfiles\Local.pubxml" />
     <Content Include="tslint.json" />
     <Content Include="StringLiteral\StringLiteral.json" />
     <Content Include="tsconfig-aot.json" />

--- a/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
+++ b/Slack.Automation/Promact.Erp.Web/Promact.Erp.Web.csproj
@@ -27,6 +27,10 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TypeScriptToolsVersion>2.1</TypeScriptToolsVersion>
+	<CopyAllFilesToSingleFolderForPackageDependsOn>
+	BuildJs;
+	$(CopyAllFilesToSingleFolderForPackageDependsOn);      
+	</CopyAllFilesToSingleFolderForPackageDependsOn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -1000,6 +1004,7 @@
     <Content Include="tslint.json" />
     <Content Include="StringLiteral\StringLiteral.json" />
     <Content Include="tsconfig-aot.json" />
+    <None Include="Properties\PublishProfiles\Promact.ERP.pubxml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
@@ -1317,11 +1322,11 @@
   <Target Name="AfterBuild">
   </Target> -->
   <Target Name="BuildJs">
-  <ItemGroup>
-  <_CustomFiles Include="build.js"/>
-  <FilesForPackagingFromProject Include="%(_CustomFiles.Identity)">
-  <DestinationRelativePath>%(Filename)%(Extension)</DestinationRelativePath>
-  </FilesForPackagingFromProject>
-  </ItemGroup>
+    <ItemGroup>
+      <_CustomFiles Include="build.js" />
+      <FilesForPackagingFromProject Include="%(_CustomFiles.Identity)">
+        <DestinationRelativePath>%(Filename)%(Extension)</DestinationRelativePath>
+      </FilesForPackagingFromProject>
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
**Fixes** - #336

**Files Changes** :
**1. Promact.Erp.Web.csproj** - configured project in such a way that build.js is included when project is published

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/slack-productivity-bots/352)
<!-- Reviewable:end -->
