### PR TITLE
Fixes - bot reconnect issue and refresh token now expired sue to which application gets stop working

### DIFF
--- a/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/OAuthLoginRepository.cs
+++ b/Slack.Automation/Promact.Core.Repository/ExternalLoginRepository/OAuthLoginRepository.cs
@@ -12,6 +12,7 @@ using Promact.Erp.Util.ExceptionHandler;
 using Promact.Erp.Util.HttpClient;
 using Promact.Erp.Util.StringLiteral;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 
@@ -72,14 +73,17 @@ namespace Promact.Core.Repository.ExternalLoginRepository
                 userInfo = new ApplicationUser() { Email = email, UserName = email, Id = userId };
                 //Creating a user with email only. Password not required
                 IdentityResult result = await _userManager.CreateAsync(userInfo);
-
-                //Adding external Oauth details
-                UserLoginInfo userLoginInfo = new UserLoginInfo(_stringConstant.PromactStringName, refreshToken);
-                var success = await _userManager.AddLoginAsync(userInfo.Id, userLoginInfo);
             }
+            else
+            {
+                var previousUserLoginInfo = (await _userManager.GetLoginsAsync(userInfo.Id)).Single(x => x.LoginProvider == _stringConstant.PromactStringName);
+                await _userManager.RemoveLoginAsync(userInfo.Id, previousUserLoginInfo);
+            }
+            //Adding external Oauth details
+            UserLoginInfo userLoginInfo = new UserLoginInfo(_stringConstant.PromactStringName, refreshToken);
+            var success = await _userManager.AddLoginAsync(userInfo.Id, userLoginInfo);
             return userInfo;
         }
-
 
         /// <summary>
         /// Method to get OAuth Server's app information


### PR DESCRIPTION
Fixes - bot reconnect issue and refresh token now expired due to which application gets stop working

Files Changes :
1. OAuthLoginRepository.cs - added functionality to update refreshtoken
2. Bot.cs - added functionality to re-connect bot when get exception

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/promact/slack-productivity-bots/360)
<!-- Reviewable:end -->
